### PR TITLE
fix(course): fix dropdown search input behavior on CommandInput

### DIFF
--- a/src/app/[lang]/(mods-pages)/courses/ClasssRefinementItem.tsx
+++ b/src/app/[lang]/(mods-pages)/courses/ClasssRefinementItem.tsx
@@ -11,7 +11,7 @@ import { getFormattedClassCode } from "@/helpers/courses";
 import useCustomMenu from '@/app/[lang]/(mods-pages)/courses/useCustomMenu';
 import { lastSemester } from "@/const/semester";
 
-const ClassRefinementItem =  ({
+const ClassRefinementItem = ({
   limit = 10,
   searchable = false,
   clientSearch = false,
@@ -33,21 +33,22 @@ const ClassRefinementItem =  ({
     attribute: 'for_class',
     limit: limit,
   })
-  
-  const { 
+
+  const {
     items: semesterItem,
-   } = useCustomMenu({
+  } = useCustomMenu({
     attribute: 'semester',
   });
 
   const selectedSemester = semesterItem.find(item => item.isRefined)?.value ?? lastSemester.id;
-  
+
   const searchParams = useSearchParams()
   useEffect(() => {
     const refinedItems = items.filter((item) => item.isRefined)
     setSelected(refinedItems.map((item) => item.value))
   }, [items, searchParams])
-  
+
+  const [typable, setEnableTyping] = useState(false)
   const [searchValue, setSearchValue] = useState('')
   const [searching, setSearching] = useState(false)
   const [selected, setSelected] = useState<string[]>([])
@@ -58,12 +59,13 @@ const ClassRefinementItem =  ({
       searchForItems(name)
     }
     if (name == '') {
-        const refined = items.filter((item) => item.isRefined)
-        setSelected(refined.map((item) => item.value))
+      const refined = items.filter((item) => item.isRefined)
+      setSelected(refined.map((item) => item.value))
     }
   }
 
   const openChange = (open: boolean) => {
+    setEnableTyping(false)
     if (open == true) {
       setSearching(true)
     }
@@ -85,15 +87,15 @@ const ClassRefinementItem =  ({
   }
 
   return <Popover modal={true} onOpenChange={openChange}>
-      <Button variant="outline" className={`w-full justify-start h-max p-0`}>
-        <PopoverTrigger asChild>
-          <div className="flex-1 text-left px-4 py-2">
+    <Button variant="outline" className={`w-full justify-start h-max p-0`}>
+      <PopoverTrigger asChild>
+        <div className="flex-1 text-left px-4 py-2">
           {searching ?
             "Selecting..." :
-            (selected.length == 0 ? 
+            (selected.length == 0 ?
               'All' :
               <div className="flex flex-col gap-1">
-                {selected.map(i => 
+                {selected.map(i =>
                   <Badge variant="outline" className="">
                     {getFormattedClassCode(i, selectedSemester)}
                   </Badge>
@@ -101,16 +103,18 @@ const ClassRefinementItem =  ({
               </div>
             )
           }
-          </div>
-        </PopoverTrigger>
-        {selected.length > 0 && <X className="px-2 w-8 h-6 cursor-pointer" onClick={clear}/>}
-      </Button>
-      
-    
+        </div>
+      </PopoverTrigger>
+      {selected.length > 0 && <X className="px-2 w-8 h-6 cursor-pointer" onClick={clear} />}
+    </Button>
+
+
     <PopoverContent className="p-0" align="start">
       <Command shouldFilter={clientSearch}>
-        {searchable && 
+        {searchable &&
           <CommandInput
+            onClick={() => setEnableTyping(true)}
+            inputMode={typable ? 'text' : 'none'}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
@@ -121,7 +125,7 @@ const ClassRefinementItem =  ({
             placeholder={placeholder}
           />
         }
-        <ScrollArea className="h-[300px]">
+        <ScrollArea onScrollCapture={() => setEnableTyping(false)} className="h-[300px]">
           <CommandList className="max-h-none">
             <CommandEmpty>No results found.</CommandEmpty>
             {items.sort((a, b) => {

--- a/src/app/[lang]/(mods-pages)/courses/FilterItem.tsx
+++ b/src/app/[lang]/(mods-pages)/courses/FilterItem.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import useCustomRefinementList from "./useCustomRefinementList";
 
-const FilterItem =  ({
+const FilterItem = ({
   attribute,
   limit = 10,
   searchable = false,
@@ -37,13 +37,14 @@ const FilterItem =  ({
     attribute: attribute,
     limit: limit,
   })
-  
+
   const searchParams = useSearchParams()
   useEffect(() => {
     const refinedItems = items.filter((item) => item.isRefined)
     setSelected(refinedItems.map((item) => item.value))
   }, [items, searchParams])
-  
+
+  const [typable, setEnableTyping] = useState(false)
   const [searchValue, setSearchValue] = useState('')
   const [searching, setSearching] = useState(false)
   const [selected, setSelected] = useState<string[]>([])
@@ -60,6 +61,7 @@ const FilterItem =  ({
   }
 
   const openChange = (open: boolean) => {
+    setEnableTyping(false)
     if (open == true) {
       setSearching(true)
     }
@@ -81,15 +83,15 @@ const FilterItem =  ({
   }
 
   return <Popover modal={true} onOpenChange={openChange}>
-      <Button variant="outline" className={`w-full justify-start h-max p-0`}>
-        <PopoverTrigger asChild>
-          <div className="flex-1 text-left px-4 py-2">
+    <Button variant="outline" className={`w-full justify-start h-max p-0`}>
+      <PopoverTrigger asChild>
+        <div className="flex-1 text-left px-4 py-2">
           {searching ?
             "Selecting..." :
-            (selected.length == 0 ? 
+            (selected.length == 0 ?
               'All' :
               <div className="flex flex-col gap-1">
-                {selected.map(i => 
+                {selected.map(i =>
                   <Badge variant="outline" className="">
                     {synonms[i] ? `${i} - ${synonms[i]}` : i}
                   </Badge>
@@ -97,16 +99,18 @@ const FilterItem =  ({
               </div>
             )
           }
-          </div>
-        </PopoverTrigger>
-        {selected.length > 0 && <X className="px-2 w-8 h-6 cursor-pointer" onClick={clear}/>}
-      </Button>
-      
-    
+        </div>
+      </PopoverTrigger>
+      {selected.length > 0 && <X className="px-2 w-8 h-6 cursor-pointer" onClick={clear} />}
+    </Button>
+
+
     <PopoverContent className="p-0" align="start">
       <Command shouldFilter={clientSearch}>
-        {searchable && 
+        {searchable &&
           <CommandInput
+            onClick={() => setEnableTyping(true)}
+            inputMode={typable ? 'text' : 'none'}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
@@ -117,7 +121,7 @@ const FilterItem =  ({
             placeholder={placeholder}
           />
         }
-        <ScrollArea className="h-[300px]">
+        <ScrollArea onScrollCapture={() => setEnableTyping(false)} className="h-[300px]">
           <CommandList className="max-h-none">
             <CommandEmpty>No results found.</CommandEmpty>
             {items.sort((a, b) => {
@@ -135,7 +139,7 @@ const FilterItem =  ({
                     <Check size={16} className={`${item.isRefined ? '' : 'opacity-0'}`} />
                   </div>
                   <span className="mr-4">
-                    {synonms[item.label] ? 
+                    {synonms[item.label] ?
                       `${item.label} - ${synonms[item.label]}` :
                       item.label
                     }


### PR DESCRIPTION
This fix introduces the following new behaviors as a workaround:
- The input mode for drop down menus will now default to `none`.
- If the menu is opened, and user clicks on the `CommandInput`, it'll change its input mode back to `text`.
- If the menu is opened, and user scrolls the `ScrollArea`, it'll change its input mode back to `none`.

---
- For more info on `inputmode`, please refer to MDN: 
  - https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
  - TL;DR 
    It defaults to `text`, and `none` will disable keyboard popup on mobile devices.
-  This should fix #375 and fix #395