### PR TITLE
chore(deps): change dependabot settings to group update into single PR.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR is just a possible solution for de-cluttering the PR list for updates and allowing maintainers to focus on important PRs.

All updates will now come in 2 groups:
1. security (security-related patches)
2. dependencies (normal updates)

You can see what it will look like on my fork: (only normal updates for now)
https://github.com/pedestrianlove/courseweb/pull/7