### PR TITLE
fix: encapsulate fetch body with encodeURIComponent for user inputs

### DIFF
--- a/src/lib/headless_ais.ts
+++ b/src/lib/headless_ais.ts
@@ -182,7 +182,7 @@ export const signInToCCXP = async (studentid: string, password: string): SignInT
                     "upgrade-insecure-requests": "1",
                 },
                 keepalive: true,
-                "body": `account=${studentid}&passwd=${password}&passwd2=${answer}&Submit=%B5n%A4J&fnstr=${pwdstr}`,
+                "body": `account=${encodeURIComponent(studentid)}&passwd=${encodeURIComponent(password)}&passwd2=${answer}&Submit=%B5n%A4J&fnstr=${pwdstr}`,
                 "method": "POST"
             });
             const resHTML = await response.arrayBuffer()
@@ -339,7 +339,7 @@ export const updateUserPassword = async (ACIXSTORE: string, oldEncryptedPassword
         },
         "referrer": "https://www.ccxp.nthu.edu.tw/ccxp/INQUIRE/PC/1/1.1/PC11001.php?ACIXSTORE=c3d1ipem8trmvk6gpq5mrv9490",
         "referrerPolicy": "strict-origin-when-cross-origin",
-        "body": `ACIXSTORE=${ACIXSTORE}&O_PASS=${oldPassword}&N_PASS=${newPassword}&N_PASS2=${newPassword}&choice=確定`,
+        "body": `ACIXSTORE=${ACIXSTORE}&O_PASS=${encodeURIComponent(oldPassword)}&N_PASS=${encodeURIComponent(newPassword)}&N_PASS2=${encodeURIComponent(newPassword)}&choice=確定`,
         "method": "POST",
         "mode": "cors",
         "credentials": "include"


### PR DESCRIPTION
This PR fixes login for passwords with special characters (not that ccxp fully supports them :P). 

This simple fix was done by adding encodeURIComponents to the body string, which was an oversight. 