### PR TITLE
fix: timetable horizontal slot updates

### DIFF
--- a/src/components/Timetable/Timetable.tsx
+++ b/src/components/Timetable/Timetable.tsx
@@ -160,7 +160,10 @@ const Timetable: FC<{
 
   if (!vertical)
     return (
-      <div className="text-center lg:mb-0 w-full overflow-x-auto overflow-y-hidden">
+      <div
+        className="text-center lg:mb-0 w-full overflow-x-auto overflow-y-hidden"
+        ref={containerRef}
+      >
         {/* Timetable, Relative overlay */}
         <div className="relative w-full">
           <table className="table-auto w-full">


### PR DESCRIPTION
This PR fixes the timetable horizontal slot not showing correctly.

The fix is to add missing reference in the rendering of horizontal table slot.