### PR TITLE
fix: timetable page UI

### DIFF
--- a/src/components/Timetable/GroupByDepartmentButton.tsx
+++ b/src/components/Timetable/GroupByDepartmentButton.tsx
@@ -40,7 +40,11 @@ const GroupByDepartmentButton = ({
   };
 
   return (
-    <Button variant="outline" onClick={handleGroupByDepartment}>
+    <Button
+      className="w-full"
+      variant="outline"
+      onClick={handleGroupByDepartment}
+    >
       {dict.timetable.actions.group_dept}
     </Button>
   );

--- a/src/components/Timetable/HeadlessSyncCourseButton.tsx
+++ b/src/components/Timetable/HeadlessSyncCourseButton.tsx
@@ -62,7 +62,12 @@ const HeadlessSyncCourseButton = () => {
   if (!ais.enabled) return <></>;
 
   return (
-    <Button variant="outline" onClick={handleSync} disabled={loading}>
+    <Button
+      className="w-full"
+      variant="outline"
+      onClick={handleSync}
+      disabled={loading}
+    >
       {!loading ? (
         <>
           <FolderSync className="w-4 h-4 mr-1" />{" "}

--- a/src/components/Timetable/TimetableCourseList.tsx
+++ b/src/components/Timetable/TimetableCourseList.tsx
@@ -324,9 +324,9 @@ export const TimetableCourseList = ({
               vertical ? verticalListSortingStrategy : rectSwappingStrategy
             }
           >
-            {displayCourseData.map((course, index) => (
+            {displayCourseData.map((course) => (
               <TimetableCourseListItem
-                key={index}
+                key={course.raw_id}
                 course={course as MinimalCourse}
                 hasConflict={
                   !!timeConflicts.find(

--- a/src/components/Timetable/TimetableSidebar.tsx
+++ b/src/components/Timetable/TimetableSidebar.tsx
@@ -72,6 +72,7 @@ const TimetableSidebar = ({
             <DropdownMenuItem asChild>
               <HeadlessSyncCourseButtonDynamic />
             </DropdownMenuItem>
+            <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
               <GroupByDepartmentButton semester={semester} />
             </DropdownMenuItem>

--- a/src/components/Timetable/TimetableSlotHorizontal.tsx
+++ b/src/components/Timetable/TimetableSlotHorizontal.tsx
@@ -30,7 +30,9 @@ const TimetableSlotHorizontal: FC<TimetableSlotProps> = ({
       className={`absolute rounded-md transform translate-y-0.5`}
       style={{
         left:
-          tableDim.header.width + course.startTime * tableDim.timetable.width,
+          tableDim.header.width +
+          course.startTime * tableDim.timetable.width +
+          2,
         top:
           tableDim.header.height +
           course.dayOfWeek * tableDim.timetable.height +
@@ -38,7 +40,7 @@ const TimetableSlotHorizontal: FC<TimetableSlotProps> = ({
         width:
           tableDim.timetable.width * (course.endTime - course.startTime + 1) -
           4,
-        height: tableDim.timetable.height / fraction,
+        height: tableDim.timetable.height / fraction - 4,
         backgroundColor: course.color,
         color: course.textColor,
       }}

--- a/src/components/Timetable/TimetableSlotVertical.tsx
+++ b/src/components/Timetable/TimetableSlotVertical.tsx
@@ -83,7 +83,7 @@ const TimetableSlotVertical: FC<TimetableSlotProps> = ({
                 {course.course.name_zh}
               </span>
             ) : (
-              <span className={cn("text-xs font-medium", textAlign)}>
+              <span className={cn("text-xs font-medium w-full", textAlign)}>
                 {course.course.name_en}
               </span>
             ))}

--- a/src/components/Timetable/TimetableSlotVertical.tsx
+++ b/src/components/Timetable/TimetableSlotVertical.tsx
@@ -46,12 +46,14 @@ const TimetableSlotVertical: FC<TimetableSlotProps> = ({
         left:
           tableDim.header.width +
           course.dayOfWeek * tableDim.timetable.width +
-          (fractionIndex - 1) * (tableDim.timetable.width / fraction),
+          (fractionIndex - 1) * (tableDim.timetable.width / fraction) +
+          2,
         top:
           tableDim.header.height + course.startTime * tableDim.timetable.height,
         width: tableDim.timetable.width / fraction - 4,
         height:
-          (course.endTime - course.startTime + 1) * tableDim.timetable.height,
+          (course.endTime - course.startTime + 1) * tableDim.timetable.height -
+          4,
         backgroundColor: course.color,
       }}
       {...props}


### PR DESCRIPTION
This PR fix bugs in the timetable page : 
- fix the horizontal and vertical timeslot not aligned properly with the timetable.
- fix the children of the more button not aligned correctly.
- fix the animation of dragging courses in course list.