### PR TITLE
Add 11320 semester

### DIFF
--- a/runners/update-courses.ts
+++ b/runners/update-courses.ts
@@ -6,7 +6,7 @@ const job = schedule.scheduleJob("0 0 * * *", async () => {
   try {
     console.log("syncing courses begin uwu");
     const res = await fetch(
-      "http://localhost:8080/api/scrape-archived-courses?semester=11310",
+      "http://localhost:8080/api/scrape-archived-courses?semester=11320",
       {
         method: "GET",
         headers: {
@@ -16,7 +16,7 @@ const job = schedule.scheduleJob("0 0 * * *", async () => {
       },
     );
     const res2 = await fetch(
-      "http://localhost:8080/api/scrape-syllabus?semester=11310",
+      "http://localhost:8080/api/scrape-syllabus?semester=11320",
       {
         method: "GET",
         headers: {
@@ -26,7 +26,7 @@ const job = schedule.scheduleJob("0 0 * * *", async () => {
       },
     );
     const res3 = await fetch(
-      "http://localhost:8080/api/sync-algolia?semester=11310",
+      "http://localhost:8080/api/sync-algolia?semester=11320",
       {
         method: "GET",
         headers: {

--- a/src/app/api/sync-courses/route.ts
+++ b/src/app/api/sync-courses/route.ts
@@ -16,7 +16,7 @@ export const GET = async (request: NextRequest) => {
     });
   }
 
-  const semester = "11310";
+  const semester = "11320";
 
   console.log("syncing courses uwu");
   console.log("scraping archived courses");

--- a/src/const/semester.ts
+++ b/src/const/semester.ts
@@ -76,6 +76,13 @@ export const semesterInfo = [
     begins: new Date(2024, 9 - 1, 2),
     ends: new Date(2024, 12 - 1, 22),
   },
+  {
+    id: "11320",
+    year: 2025,
+    semester: 2,
+    begins: new Date(2025, 2 - 1, 17),
+    ends: new Date(2025, 6 - 1, 8),
+  },
 ];
 
 export const currentSemester = semesterInfo.find((semester) => {


### PR DESCRIPTION
Fixes #587

Add new semester definition for 11320 and update relevant files to sync courses for the new semester.

* **src/const/semester.ts**
  - Add a new object to the `semesterInfo` array with the properties for the 11320 semester.
* **src/app/api/sync-courses/route.ts**
  - Update the `semester` variable to "11320".
* **runners/update-courses.ts**
  - Update the `semester` parameter in the fetch requests to "11320".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nthumodifications/courseweb/pull/588?shareId=8974640d-078f-46d4-ba29-f39bcf23056b).