### PR TITLE
fix(timetable): timetable parsing will now respect same day multi session courses

### DIFF
--- a/src/helpers/timetable.ts
+++ b/src/helpers/timetable.ts
@@ -14,24 +14,57 @@ export const createTimetableFromCourses = (
   ),
 ) => {
   const newTimetableData: CourseTimeslotData[] = [];
+
+  // For each course, we first seperate the timeslot strings into individual timeslots
+  // Then we group consecutive timeslots into a single item
   data!.forEach((course) => {
-    //get unique days first
     if (!hasTimes(course)) {
       return;
     }
     course.times.forEach((time_str, index) => {
+      // Split the timeslot string into individual timeslots
       const timeslots = time_str
         .match(/.{1,2}/g)
-        ?.map((day) => ({ day: day[0], time: day[1] }));
-      const days = timeslots!
-        .map((time) => time.day)
-        .filter((day, index, self) => self.indexOf(day) === index);
-      days.forEach((day) => {
-        const times = timeslots!
-          .filter((time) => time.day == day)
-          .map((time) =>
-            scheduleTimeSlots.map((m) => m.time).indexOf(time.time),
-          );
+        ?.map((day) => ({ day: day[0], time: day[1] })); // Day is "MTWRFS" and time is "123456789abc"
+
+      // Group consecutive timeslots by reducing the array
+      // 1. get first timeslot, check if next consecutive timeslot is present
+      // 2. if present, group them together
+      // 3. if not present, push the group to the groupedTimeslots array
+      const groupedTimeslots: { day: string; time: string }[][] = [];
+      timeslots!.reduce((acc, curr) => {
+        if (acc.length === 0) {
+          acc.push([curr]);
+        } else {
+          const last = acc[acc.length - 1];
+          const lastTime = last[last.length - 1];
+          const lastTimeIndex = scheduleTimeSlots
+            .map((m) => m.time)
+            .indexOf(lastTime.time);
+          const currTimeIndex = scheduleTimeSlots
+            .map((m) => m.time)
+            .indexOf(curr.time);
+          // if timeslots are consecutive and on the same day
+          if (
+            lastTimeIndex + 1 === currTimeIndex &&
+            lastTime.day === curr.day
+          ) {
+            last.push(curr);
+          }
+          // else, push to new group
+          else {
+            acc.push([curr]);
+          }
+        }
+        return acc;
+      }, groupedTimeslots);
+
+      groupedTimeslots.forEach((group) => {
+        const day = group[0].day;
+        const times = group.map((time) =>
+          scheduleTimeSlots.map((m) => m.time).indexOf(time.time),
+        );
+
         //get the start and end time
         const startTime = Math.min(...times);
         const endTime = Math.max(...times);


### PR DESCRIPTION
This pull request includes changes to improve the `createTimetableFromCourses` function in `src/helpers/timetable.ts`. The main focus is on enhancing the handling of course timeslots by splitting them into individual timeslots and grouping consecutive timeslots more efficiently.

Enhancements to timeslot handling:

* Added logic to split timeslot strings into individual timeslots for each course.
* Implemented a method to group consecutive timeslots into single items by reducing the array of timeslots.
* Ensured that grouped timeslots are processed correctly to determine the start and end times for each group.