### PR TITLE
feat: add EEClass integration with OAuth login and new app entry

### DIFF
--- a/src/const/apps.ts
+++ b/src/const/apps.ts
@@ -24,6 +24,7 @@ import {
   University,
   CreditCardIcon,
   CalendarIcon,
+  Notebook,
 } from "lucide-react";
 
 export const categories: {
@@ -134,6 +135,16 @@ export const apps: {
     title_en: "Academic Information System",
     href: "https://www.ccxp.nthu.edu.tw/ccxp/COURSE/JH/7/7.1/7.1.3/logout.php",
     Icon: University,
+    target: "_blank",
+    ais: true,
+  },
+  {
+    id: "eeclass",
+    category: "campuslife",
+    title_zh: "eeclass",
+    title_en: "eeclass",
+    href: "eeclass",
+    Icon: Notebook,
     target: "_blank",
     ais: true,
   },

--- a/src/hooks/contexts/useHeadlessAIS.tsx
+++ b/src/hooks/contexts/useHeadlessAIS.tsx
@@ -23,6 +23,7 @@ import {
   signOut as serverSignOut,
   signIn as serverSignIn,
 } from "@/lib/firebase/auth";
+import { signInEeclassOauth } from "@/lib/headless_ais/elearning";
 
 const headlessAISContext = createContext<
   ReturnType<typeof useHeadlessAISProvider>
@@ -40,6 +41,7 @@ const headlessAISContext = createContext<
   isACIXSTOREValid: false,
   openChangePassword: false,
   setOpenChangePassword: () => {},
+  getEEClassUrl: async () => "",
 });
 
 const RenewPasswordDialogDynamic = dynamic(
@@ -236,6 +238,22 @@ const useHeadlessAISProvider = () => {
     return () => clearInterval(interval);
   }, [headlessAIS]);
 
+  const getEEClassUrl = async () => {
+    if (!headlessAIS.enabled) return "";
+    const res = await signInEeclassOauth(
+      headlessAIS.studentid,
+      headlessAIS.password,
+    );
+    if ("error" in res) {
+      toast({
+        title: "登入失敗",
+        description: res.error.message,
+      });
+      return "";
+    }
+    return res.url;
+  };
+
   return {
     user,
     ais,
@@ -247,6 +265,7 @@ const useHeadlessAISProvider = () => {
     initializing,
     openChangePassword,
     setOpenChangePassword,
+    getEEClassUrl,
   };
 };
 

--- a/src/lib/headless_ais/elearning.ts
+++ b/src/lib/headless_ais/elearning.ts
@@ -1,0 +1,140 @@
+"use server";
+import { decrypt } from "@/lib/headless_ais";
+import { parseHTML } from "linkedom";
+
+type EEClassOauthReturn = {
+  url: string;
+};
+
+export const signInEeclassOauth = async (
+  studentid: string,
+  encryptedPassword: string,
+) => {
+  try {
+    const password = await decrypt(encryptedPassword);
+
+    const oauthLogin = async (_try = 0): Promise<EEClassOauthReturn> => {
+      if (_try == 3) {
+        throw new Error(
+          "登入出錯，但不知道爲什麽 :( Something wrong, idk why.",
+        );
+      }
+
+      let tries = 0,
+        captchaUrl = "",
+        captcha = "",
+        PHPSESSID = "";
+      do {
+        const res = await fetch(
+          `https://oauth.ccxp.nthu.edu.tw/v1.1/authorize.php?response_type=code&client_id=eeclass&redirect_uri=https%3A%2F%2Feeclass.nthu.edu.tw%2Fservice%2Foauth%2F&scope=lmsid+userid&state=&ui_locales=en-US`,
+          {
+            headers: {
+              accept:
+                "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+              "accept-language": "en-US,en;q=0.9",
+              "sec-ch-ua":
+                '"Not A(Brand";v="99", "Microsoft Edge";v="121", "Chromium";v="121"',
+              "sec-ch-ua-mobile": "?0",
+              "sec-ch-ua-platform": '"Windows"',
+              "sec-fetch-dest": "document",
+              "sec-fetch-mode": "navigate",
+              "sec-fetch-site": "same-site",
+              "sec-fetch-user": "?1",
+              "upgrade-insecure-requests": "1",
+            },
+            referrer: `https://eeclass.nthu.edu.tw/`,
+            referrerPolicy: "strict-origin-when-cross-origin",
+            body: null,
+            method: "GET",
+            mode: "cors",
+            credentials: "same-origin",
+            cache: "no-cache",
+          },
+        );
+
+        const html = await res.arrayBuffer().then((buffer) => {
+          const decoder = new TextDecoder("big5");
+          const text = decoder.decode(buffer);
+          return text;
+        });
+        const { document: doc } = parseHTML(html, "text/html");
+        const setCookie = res.headers.getSetCookie();
+
+        PHPSESSID = setCookie
+          .find((cookie: string) => cookie.startsWith("PHPSESSID="))
+          ?.split(";")[0]
+          .split("=")[1] as string;
+
+        const audio = doc.querySelector(
+          'source[id="captcha_image_source_wav"]',
+        ) as HTMLSourceElement;
+        captchaUrl = audio.src;
+
+        captcha = await (
+          await fetch(
+            `https://sr.nthumods.com/?url=${"https://oauth.ccxp.nthu.edu.tw/v1.1/" + captchaUrl}&id=${PHPSESSID}`,
+          )
+        ).text();
+        if (captcha.length == 4) break;
+      } while (tries <= 5);
+
+      process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
+      const resLogin = await fetch(
+        `https://oauth.ccxp.nthu.edu.tw/v1.1/authorize.php?response_type=code&client_id=eeclass&redirect_uri=https%3A%2F%2Feeclass.nthu.edu.tw%2Fservice%2Foauth%2F&scope=lmsid+userid&state=&ui_locales=en-US`,
+        {
+          headers: {
+            accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "accept-language": "en-US,en;q=0.9",
+            "cache-control": "max-age=0",
+            "content-type": "application/x-www-form-urlencoded",
+            "sec-ch-ua":
+              '"NotA(Brand";v="99", "Microsoft Edge";v="121", "Chromium";v="121"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"Windows"',
+            "sec-fetch-dest": "document",
+            "sec-fetch-mode": "navigate",
+            "sec-fetch-site": "same-origin",
+            "sec-fetch-user": "?1",
+            "upgrade-insecure-requests": "1",
+            cookie: `PHPSESSID=${PHPSESSID}`,
+          },
+          keepalive: true,
+          redirect: "manual",
+          referrer: `https://oauth.ccxp.nthu.edu.tw/v1.1/authorize.php?response_type=code&client_id=eeclass&redirect_uri=https%3A%2F%2Feeclass.nthu.edu.tw%2Fservice%2Foauth%2F&scope=lmsid+userid&state=&ui_locales=en-US`,
+          referrerPolicy: "strict-origin-when-cross-origin",
+          body: `id=${studentid}&password=${password}&school=&cid=&captcha_id=${captchaUrl.substring("captchaplay.php?id=".length)}&captcha=${captcha}&action=login`,
+          method: "POST",
+          mode: "cors",
+          credentials: "same-origin",
+          cache: "no-cache",
+        },
+      );
+
+      const resLoginHTML = await resLogin.text();
+      if (resLoginHTML.match("Wrong captcha")) {
+        return await oauthLogin(_try++);
+      } else if (resLoginHTML.match("Incorrect account or password")) {
+        throw new Error("帳號或密碼錯誤 Incorrect Login Credentials");
+      } else if (
+        !resLogin.headers.has("Location") ||
+        !resLogin.headers.get("Location")?.includes("service/oauth")
+      ) {
+        throw new Error("未知錯誤 Unknown Login Error");
+      }
+      return {
+        url: resLogin.headers.get("Location") as string,
+      };
+    };
+    return await oauthLogin();
+  } catch (error) {
+    console.error(error);
+    if (error instanceof Error) return { error: { message: error.message } };
+    return { error: { message: "Unknown Error" } };
+  }
+};
+
+type ELearnOauthReturn = {
+  cookie: string;
+  MoodleSessionM35: string;
+};


### PR DESCRIPTION
Snippet from #290 as PR is currently stale.

This pull request includes significant enhancements to the `eeclass` integration, including the addition of a new app and the implementation of OAuth login for `eeclass`. The most important changes are the addition of the `eeclass` app to the `apps` list, the implementation of the `signInEeclassOauth` function, and the integration of this function into the `useHeadlessAIS` and `useLaunchApp` hooks.

### Enhancements to `eeclass` integration:

* [`src/const/apps.ts`](diffhunk://#diff-7e9b0acd42898bcb9013ea5964219ca52bbf82428db12fd07f5574c57d91d1d2R27): Added the `eeclass` app to the `apps` list and imported the `Notebook` icon from `lucide-react`. [[1]](diffhunk://#diff-7e9b0acd42898bcb9013ea5964219ca52bbf82428db12fd07f5574c57d91d1d2R27) [[2]](diffhunk://#diff-7e9b0acd42898bcb9013ea5964219ca52bbf82428db12fd07f5574c57d91d1d2R141-R150)

* [`src/lib/headless_ais/elearning.ts`](diffhunk://#diff-3600af53269d194f50837ce0748762e8f5d96ec21d98a39c5f65595f9e4df324R1-R140): Implemented the `signInEeclassOauth` function to handle OAuth login for `eeclass`, including captcha handling and error management.

### Integration with hooks:

* [`src/hooks/contexts/useHeadlessAIS.tsx`](diffhunk://#diff-81d9049eaa56d8b87ceb5034ad7e4c750bb3637d7d393efd431e8df2f3b5dd6eR26): Imported the `signInEeclassOauth` function, added the `getEEClassUrl` function to the context provider, and integrated it into the `useHeadlessAISProvider` hook. [[1]](diffhunk://#diff-81d9049eaa56d8b87ceb5034ad7e4c750bb3637d7d393efd431e8df2f3b5dd6eR26) [[2]](diffhunk://#diff-81d9049eaa56d8b87ceb5034ad7e4c750bb3637d7d393efd431e8df2f3b5dd6eR44) [[3]](diffhunk://#diff-81d9049eaa56d8b87ceb5034ad7e4c750bb3637d7d393efd431e8df2f3b5dd6eR241-R256) [[4]](diffhunk://#diff-81d9049eaa56d8b87ceb5034ad7e4c750bb3637d7d393efd431e8df2f3b5dd6eR268)

* [`src/hooks/useLaunchApp.tsx`](diffhunk://#diff-1a0abf920c6deeffb28d42ed5c533b929b940193bcd5d72cfbcfc833b7b0b2f9L11-R11): Updated the `useLaunchApp` hook to use the `getEEClassUrl` function when launching the `eeclass` app. [[1]](diffhunk://#diff-1a0abf920c6deeffb28d42ed5c533b929b940193bcd5d72cfbcfc833b7b0b2f9L11-R11) [[2]](diffhunk://#diff-1a0abf920c6deeffb28d42ed5c533b929b940193bcd5d72cfbcfc833b7b0b2f9R28-R38) [[3]](diffhunk://#diff-1a0abf920c6deeffb28d42ed5c533b929b940193bcd5d72cfbcfc833b7b0b2f9R63)