### PR TITLE
Improve SEO with metadata, sitemap, and structured data

### DIFF
--- a/src/app/[lang]/(mods-pages)/(venues)/venues/@content/[locationId]/page.tsx
+++ b/src/app/[lang]/(mods-pages)/(venues)/venues/@content/[locationId]/page.tsx
@@ -25,9 +25,23 @@ export const generateMetadata = ({
     params
 }: Props, parent: ResolvingMetadata) => {
     const venueId = decodeURI(params.locationId)
+    const venueUrl = `https://nthumods.com/zh/venues/${encodeURIComponent(params.locationId)}`
     return {
-        ...parent,
-        title: `${venueId}`
+        title: venueId,
+        description: `查看 ${venueId} 的課程時刻表與位置資訊。View course timetable and location info for ${venueId} at NTHU.`,
+        openGraph: {
+            title: `${venueId} | NTHUMods`,
+            description: `查看 ${venueId} 的課程時刻表與位置資訊。`,
+            url: venueUrl,
+        },
+        twitter: {
+            card: 'summary' as const,
+            title: `${venueId} | NTHUMods`,
+            description: `查看 ${venueId} 的課程時刻表與位置資訊。`,
+        },
+        alternates: {
+            canonical: venueUrl,
+        },
     }
 }
 

--- a/src/app/[lang]/(mods-pages)/(venues)/venues/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/(venues)/venues/layout.tsx
@@ -7,9 +7,30 @@ type LocationLayoutProps = PropsWithChildren<{
     sidebar: ReactNode,
 }>
 
-export const metadata = ({
-    title: '地點 Venues'
-})
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: '地點查詢 Venues',
+    description: '查詢國立清華大學校園建築與教室位置，含課程使用時刻表。Find NTHU campus buildings and classroom locations with course timetables.',
+    keywords: ['清大地點', 'NTHU venues', '清大教室', 'NTHU classroom', '清大建築', 'NTHU buildings', '清大地圖'],
+    openGraph: {
+        title: '地點查詢 | NTHUMods',
+        description: '查詢國立清華大學校園建築與教室位置，含課程使用時刻表。',
+        url: 'https://nthumods.com/zh/venues',
+    },
+    twitter: {
+        card: 'summary',
+        title: '地點查詢 | NTHUMods',
+        description: '查詢國立清華大學校園建築與教室位置，含課程使用時刻表。',
+    },
+    alternates: {
+        canonical: 'https://nthumods.com/zh/venues',
+        languages: {
+            en: 'https://nthumods.com/en/venues',
+            zh: 'https://nthumods.com/zh/venues',
+        },
+    },
+}
 
 const LocationLayout: FC<LocationLayoutProps> = async ({ content, sidebar, children, ...anything }) => {
     return <div className="h-full grid grid-cols-1 md:grid-cols-[500px_auto] overflow-hidden">

--- a/src/app/[lang]/(mods-pages)/bus/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/bus/layout.tsx
@@ -1,8 +1,28 @@
 import Fade from '@/components/Animation/Fade'
+import { Metadata } from 'next'
 import { PropsWithChildren } from 'react'
 
-export const metadata = {
-    title: '校園公車 Bus Schedule'
+export const metadata: Metadata = {
+    title: '校園公車 Bus Schedule',
+    description: '國立清華大學校園公車時間表，含即時到站資訊與路線查詢。NTHU campus bus schedule with real-time arrival info and route search.',
+    keywords: ['清大校車', 'NTHU Bus', 'NTHU campus bus', '清大公車時刻表', 'NTHU bus schedule', '清大交通'],
+    openGraph: {
+        title: '校園公車 | NTHUMods',
+        description: '國立清華大學校園公車時間表，含即時到站資訊與路線查詢。',
+        url: 'https://nthumods.com/zh/bus',
+    },
+    twitter: {
+        card: 'summary',
+        title: '校園公車 | NTHUMods',
+        description: '國立清華大學校園公車時間表，含即時到站資訊與路線查詢。',
+    },
+    alternates: {
+        canonical: 'https://nthumods.com/zh/bus',
+        languages: {
+            en: 'https://nthumods.com/en/bus',
+            zh: 'https://nthumods.com/zh/bus',
+        },
+    },
 }
 
 export default function ClientLayout({ children }: PropsWithChildren<{}>) {

--- a/src/app/[lang]/(mods-pages)/bus/stop/[stopId]/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/bus/stop/[stopId]/layout.tsx
@@ -1,0 +1,46 @@
+import { PropsWithChildren } from 'react'
+import { Metadata, ResolvingMetadata } from 'next'
+import { stops } from '@/const/bus'
+
+type Props = {
+    params: { stopId: string; lang: string }
+}
+
+export async function generateMetadata({ params }: Props, parent: ResolvingMetadata): Promise<Metadata> {
+    const stopId = params.stopId
+    const stopCode = stopId.replace(/[UD]$/, '')
+    const stop = stops.find(s => s.code === stopCode)
+    const direction = stopId.endsWith('U') ? '上山' : stopId.endsWith('D') ? '下山' : ''
+    const directionEn = stopId.endsWith('U') ? 'Uphill' : stopId.endsWith('D') ? 'Downhill' : ''
+
+    const nameZh = stop ? `${stop.name_zh}${direction ? ` ${direction}` : ''}` : stopId
+    const nameEn = stop ? `${stop.name_en}${directionEn ? ` ${directionEn}` : ''}` : stopId
+    const stopUrl = `https://nthumods.com/${params.lang}/bus/stop/${stopId}`
+
+    return {
+        title: `${nameZh} ${nameEn} 公車站`,
+        description: `查看 ${nameZh} 公車站的即時到站資訊與時刻表。View real-time bus arrival info and schedule for ${nameEn} stop at NTHU.`,
+        keywords: [`清大公車 ${nameZh}`, `NTHU bus ${nameEn}`, '清大校車', 'NTHU campus bus'],
+        openGraph: {
+            title: `${nameZh} | 校園公車 | NTHUMods`,
+            description: `查看 ${nameZh} 公車站的即時到站資訊與時刻表。`,
+            url: stopUrl,
+        },
+        twitter: {
+            card: 'summary',
+            title: `${nameZh} | 校園公車 | NTHUMods`,
+            description: `查看 ${nameZh} 公車站的即時到站資訊與時刻表。`,
+        },
+        alternates: {
+            canonical: stopUrl,
+            languages: {
+                en: `https://nthumods.com/en/bus/stop/${stopId}`,
+                zh: `https://nthumods.com/zh/bus/stop/${stopId}`,
+            },
+        },
+    }
+}
+
+export default function BusStopLayout({ children }: PropsWithChildren) {
+    return <>{children}</>
+}

--- a/src/app/[lang]/(mods-pages)/courses/[courseId]/page.tsx
+++ b/src/app/[lang]/(mods-pages)/courses/[courseId]/page.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge"
 import supabase, { CourseDefinition, CourseScoreDefinition } from '@/config/supabase';
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { timetableColors } from "@/const/timetableColors";
+import JsonLd from "@/components/JsonLd";
 
 
 type PageProps = {
@@ -29,27 +30,46 @@ type PageProps = {
 }
 
 export async function generateMetadata({ params }: PageProps, parent: ResolvingMetadata) {
-    const course = await getCourseWithSyllabus(decodeURI(params.courseId as string));
+    const courseId = decodeURI(params.courseId as string);
+    const course = await getCourseWithSyllabus(courseId);
 
     if (!course) return {
-        ...parent,
-        title: '404',
-        description: '找不到課程'
+        title: '404 - 找不到課程',
+        description: '找不到課程',
+        robots: { index: false, follow: false },
     }
 
+    const courseCode = `${course.department} ${course.course}-${course.class}`
+    const title = `${courseCode} ${course.name_zh} ${course.name_en}`
+    const teachers = [course.teacher_zh?.join(','), course.teacher_en?.join(',')].filter(Boolean).join(' / ')
+    const brief = course.course_syllabus?.brief ?? ''
+    const description = [teachers, brief].filter(Boolean).join(' — ').slice(0, 200)
+    const courseUrl = `https://nthumods.com/zh/courses/${encodeURIComponent(courseId)}`
+
     return {
-        ...parent,
-        title: `${course?.department} ${course?.course}-${course?.class} ${course!.name_zh} ${course!.name_en}`,
-        description: `${course!.teacher_zh?.join(',')} ${course!.teacher_en?.join(',')} \n ${course!.course_syllabus ? course!.course_syllabus.brief: ""}`,
+        title,
+        description,
+        keywords: [course.name_zh, course.name_en, courseCode, ...(course.teacher_zh ?? []), 'NTHU course', '清大課程'],
         openGraph: {
-            type: 'website',
-            title: `${course?.department} ${course?.course}-${course?.class} ${course!.name_zh} ${course!.name_en} | NTHUMods`,
-            description: `${course!.teacher_zh?.join(',')} ${course!.teacher_en?.join(',')} \n ${course!.course_syllabus ? course!.course_syllabus.brief: ""}`,
-            url: 'https://nthumods.com',
+            type: 'article',
+            title: `${title} | NTHUMods`,
+            description,
+            url: courseUrl,
             siteName: 'NTHUMods',
-            countryName: 'Taiwan',
-            locale: 'en, zh'
-        }
+            locale: 'zh_TW',
+        },
+        twitter: {
+            card: 'summary',
+            title: `${title} | NTHUMods`,
+            description,
+        },
+        alternates: {
+            canonical: courseUrl,
+            languages: {
+                en: `https://nthumods.com/en/courses/${encodeURIComponent(courseId)}`,
+                zh: `https://nthumods.com/zh/courses/${encodeURIComponent(courseId)}`,
+            },
+        },
     }
 }
 
@@ -101,7 +121,29 @@ const CourseDetailPage = async ({ params }: PageProps & LangProps) => {
     const timetableData = showTimetable ? createTimetableFromCourses([course as MinimalCourse], colorMap) : [];
     
 
+    const courseJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'Course',
+        name: course.name_zh,
+        alternateName: course.name_en,
+        description: course.course_syllabus?.brief ?? `${course.department} ${course.course}-${course.class} ${course.name_zh}`,
+        url: `https://nthumods.com/zh/courses/${encodeURIComponent(courseId)}`,
+        provider: {
+            '@type': 'CollegeOrUniversity',
+            name: '國立清華大學',
+            alternateName: 'National Tsing Hua University',
+            url: 'https://www.nthu.edu.tw',
+        },
+        ...(course.teacher_zh?.length ? {
+            instructor: course.teacher_zh.map(t => ({ '@type': 'Person', name: t })),
+        } : {}),
+        inLanguage: 'zh-TW',
+        educationalLevel: 'University',
+        courseCode: `${course.department} ${course.course}-${course.class}`,
+    }
+
     return <Fade>
+        <JsonLd data={courseJsonLd} />
         <div className="grid grid-cols-1 xl:grid-cols-[auto_240px] pb-6 px-4 text-gray-500 dark:text-gray-300">
             <div className="space-y-2">
                 <div className="flex flex-col md:flex-row md:items-end gap-4">

--- a/src/app/[lang]/(mods-pages)/courses/[courseId]/page.tsx
+++ b/src/app/[lang]/(mods-pages)/courses/[courseId]/page.tsx
@@ -23,7 +23,18 @@ import supabase, { CourseDefinition, CourseScoreDefinition } from '@/config/supa
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { timetableColors } from "@/const/timetableColors";
 import JsonLd from "@/components/JsonLd";
+import { lastSemester } from '@/const/semester';
 
+// Allow on-demand rendering for courses not pre-rendered at build time
+export const dynamicParams = true
+
+export async function generateStaticParams() {
+    const { data } = await supabase
+        .from('courses')
+        .select('raw_id')
+        .eq('semester', lastSemester.id)
+    return (data ?? []).map(c => ({ courseId: encodeURIComponent(c.raw_id) }))
+}
 
 type PageProps = {
     params: { courseId?: string }
@@ -121,13 +132,26 @@ const CourseDetailPage = async ({ params }: PageProps & LangProps) => {
     const timetableData = showTimetable ? createTimetableFromCourses([course as MinimalCourse], colorMap) : [];
     
 
+    const lang = params.lang ?? 'zh'
+    const courseUrl = `https://nthumods.com/${lang}/courses/${encodeURIComponent(courseId)}`
+
+    const breadcrumbJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+            { '@type': 'ListItem', position: 1, name: '課程查詢', item: `https://nthumods.com/${lang}/courses` },
+            { '@type': 'ListItem', position: 2, name: course.department, item: `https://nthumods.com/${lang}/courses/dept/${course.department}` },
+            { '@type': 'ListItem', position: 3, name: `${course.name_zh}`, item: courseUrl },
+        ],
+    }
+
     const courseJsonLd = {
         '@context': 'https://schema.org',
         '@type': 'Course',
         name: course.name_zh,
         alternateName: course.name_en,
         description: course.course_syllabus?.brief ?? `${course.department} ${course.course}-${course.class} ${course.name_zh}`,
-        url: `https://nthumods.com/zh/courses/${encodeURIComponent(courseId)}`,
+        url: courseUrl,
         provider: {
             '@type': 'CollegeOrUniversity',
             name: '國立清華大學',
@@ -143,6 +167,7 @@ const CourseDetailPage = async ({ params }: PageProps & LangProps) => {
     }
 
     return <Fade>
+        <JsonLd data={breadcrumbJsonLd} />
         <JsonLd data={courseJsonLd} />
         <div className="grid grid-cols-1 xl:grid-cols-[auto_240px] pb-6 px-4 text-gray-500 dark:text-gray-300">
             <div className="space-y-2">

--- a/src/app/[lang]/(mods-pages)/courses/dept/[department]/page.tsx
+++ b/src/app/[lang]/(mods-pages)/courses/dept/[department]/page.tsx
@@ -1,0 +1,178 @@
+import { Metadata, ResolvingMetadata } from 'next'
+import Link from 'next/link'
+import { departments } from '@/const/departments'
+import { lastSemester, semesterInfo } from '@/const/semester'
+import supabase from '@/config/supabase'
+import { toPrettySemester } from '@/helpers/semester'
+import JsonLd from '@/components/JsonLd'
+import { LangProps } from '@/types/pages'
+
+type Props = {
+    params: { department: string; lang: string }
+}
+
+export const dynamicParams = true
+
+export async function generateStaticParams() {
+    return departments.map(d => ({ department: d.code }))
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const dept = departments.find(d => d.code === params.department)
+    if (!dept) return { title: '找不到系所', robots: { index: false, follow: false } }
+
+    const title = `${dept.name_zh} ${dept.code} 課程查詢`
+    const description = `查詢國立清華大學${dept.name_zh}（${dept.name_en}）所有課程，包含課程名稱、教師與時段。Browse all NTHU ${dept.name_en} courses.`
+    const url = `https://nthumods.com/${params.lang}/courses/dept/${dept.code}`
+
+    return {
+        title,
+        description,
+        keywords: [
+            `清大${dept.name_zh}課程`,
+            `NTHU ${dept.name_en} courses`,
+            `清大${dept.code}`,
+            `${dept.name_zh}選課`,
+            `NTHU ${dept.code}`,
+            '國立清華大學課程',
+        ],
+        openGraph: {
+            title: `${title} | NTHUMods`,
+            description,
+            url,
+        },
+        twitter: {
+            card: 'summary',
+            title: `${title} | NTHUMods`,
+            description,
+        },
+        alternates: {
+            canonical: url,
+            languages: {
+                en: `https://nthumods.com/en/courses/dept/${dept.code}`,
+                zh: `https://nthumods.com/zh/courses/dept/${dept.code}`,
+            },
+        },
+    }
+}
+
+const getCoursesForDept = async (deptCode: string) => {
+    const semesters = semesterInfo.map(s => s.id)
+    const { data, error } = await supabase
+        .from('courses')
+        .select('raw_id, name_zh, name_en, teacher_zh, semester, course, class')
+        .eq('department', deptCode)
+        .in('semester', semesters)
+        .order('semester', { ascending: false })
+        .order('course', { ascending: true })
+    if (error) return []
+    return data ?? []
+}
+
+const DepartmentPage = async ({ params }: Props & LangProps) => {
+    const dept = departments.find(d => d.code === params.department)
+    if (!dept) return (
+        <div className="py-6 px-4">
+            <h1 className="text-2xl font-bold">找不到系所</h1>
+            <Link href={`/${params.lang}/courses`} className="text-blue-500 underline mt-2 block">
+                回課程查詢
+            </Link>
+        </div>
+    )
+
+    const courses = await getCoursesForDept(params.department)
+
+    // Group by semester
+    const bySemester: Record<string, typeof courses> = {}
+    for (const c of courses) {
+        if (!bySemester[c.semester]) bySemester[c.semester] = []
+        bySemester[c.semester].push(c)
+    }
+    const semestersDesc = Object.keys(bySemester).sort((a, b) => b.localeCompare(a))
+
+    const breadcrumbJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+            { '@type': 'ListItem', position: 1, name: '課程查詢', item: `https://nthumods.com/${params.lang}/courses` },
+            { '@type': 'ListItem', position: 2, name: `${dept.name_zh} ${dept.code}`, item: `https://nthumods.com/${params.lang}/courses/dept/${dept.code}` },
+        ],
+    }
+
+    const itemListJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'ItemList',
+        name: `${dept.name_zh} 課程列表`,
+        description: `國立清華大學${dept.name_zh}（${dept.name_en}）課程列表`,
+        numberOfItems: courses.length,
+        itemListElement: courses.slice(0, 100).map((c, i) => ({
+            '@type': 'ListItem',
+            position: i + 1,
+            name: `${c.name_zh} ${c.name_en ?? ''}`.trim(),
+            url: `https://nthumods.com/${params.lang}/courses/${encodeURIComponent(c.raw_id)}`,
+        })),
+    }
+
+    return (
+        <div className="py-6 px-4 max-w-4xl">
+            <JsonLd data={breadcrumbJsonLd} />
+            <JsonLd data={itemListJsonLd} />
+
+            <nav className="text-sm text-gray-500 mb-4">
+                <Link href={`/${params.lang}/courses`} className="hover:underline">課程查詢</Link>
+                <span className="mx-2">/</span>
+                <span>{dept.name_zh} {dept.code}</span>
+            </nav>
+
+            <h1 className="text-2xl font-bold mb-1">{dept.name_zh}</h1>
+            <h2 className="text-base text-gray-500 mb-1">{dept.name_en}</h2>
+            <p className="text-sm text-gray-400 mb-6">{courses.length} 門課程</p>
+
+            <Link
+                href={`/${params.lang}/courses?department[0]=${dept.code}`}
+                className="inline-block mb-6 px-4 py-2 text-sm bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 rounded-md hover:bg-purple-200 dark:hover:bg-purple-800 transition-colors"
+            >
+                進階篩選與搜尋 →
+            </Link>
+
+            <div className="space-y-8">
+                {semestersDesc.map(semId => (
+                    <section key={semId}>
+                        <h3 className="text-lg font-semibold mb-3 text-gray-700 dark:text-gray-300">
+                            {toPrettySemester(semId)} 學期
+                        </h3>
+                        <ul className="divide-y divide-gray-100 dark:divide-neutral-800">
+                            {bySemester[semId].map(course => (
+                                <li key={course.raw_id}>
+                                    <Link
+                                        href={`/${params.lang}/courses/${encodeURIComponent(course.raw_id)}`}
+                                        className="flex flex-col sm:flex-row sm:items-center gap-1 py-3 hover:bg-gray-50 dark:hover:bg-neutral-900 px-2 -mx-2 rounded"
+                                    >
+                                        <span className="text-xs font-mono text-purple-600 dark:text-purple-400 w-20 shrink-0">
+                                            {params.department} {course.course}-{course.class}
+                                        </span>
+                                        <span className="font-medium text-gray-900 dark:text-gray-100 flex-1">
+                                            {course.name_zh}
+                                        </span>
+                                        {course.name_en && (
+                                            <span className="text-sm text-gray-500 dark:text-gray-400">
+                                                {course.name_en}
+                                            </span>
+                                        )}
+                                        {course.teacher_zh && course.teacher_zh.length > 0 && (
+                                            <span className="text-xs text-gray-400 shrink-0">
+                                                {course.teacher_zh.join(', ')}
+                                            </span>
+                                        )}
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+export default DepartmentPage

--- a/src/app/[lang]/(mods-pages)/courses/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/courses/layout.tsx
@@ -1,8 +1,28 @@
 import { PropsWithChildren } from 'react'
 import Fade from '@/components/Animation/Fade';
+import { Metadata } from 'next';
 
-export const metadata = {
-    title: '課表 Courses'
+export const metadata: Metadata = {
+    title: '課程查詢 Course Search',
+    description: '搜尋國立清華大學所有課程，包含課程資訊、教師、時段與大綱。Search all NTHU courses by name, instructor, department, or time slot.',
+    keywords: ['清大課程查詢', 'NTHU course search', '清大選課', 'NTHU courses', '清華大學課程', 'NTHU course catalog'],
+    openGraph: {
+        title: '課程查詢 | NTHUMods',
+        description: '搜尋國立清華大學所有課程，包含課程資訊、教師、時段與大綱。',
+        url: 'https://nthumods.com/zh/courses',
+    },
+    twitter: {
+        card: 'summary',
+        title: '課程查詢 | NTHUMods',
+        description: '搜尋國立清華大學所有課程，包含課程資訊、教師、時段與大綱。',
+    },
+    alternates: {
+        canonical: 'https://nthumods.com/zh/courses',
+        languages: {
+            en: 'https://nthumods.com/en/courses',
+            zh: 'https://nthumods.com/zh/courses',
+        },
+    },
 }
 
 export default function ClientLayout({ children }: PropsWithChildren<{}>) {

--- a/src/app/[lang]/(mods-pages)/settings/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/settings/layout.tsx
@@ -1,8 +1,14 @@
 import { PropsWithChildren } from 'react'
 import Fade from '@/components/Animation/Fade';
+import { Metadata } from 'next';
 
-export const metadata = {
-    title: '設定 Settings'
+export const metadata: Metadata = {
+    title: '設定 Settings',
+    description: '設定 NTHUMods 的個人化偏好，包含語言、主題與通知。Customize your NTHUMods preferences including language, theme, and notifications.',
+    robots: {
+        index: false,
+        follow: false,
+    },
 }
 
 export default function ClientLayout({ children }: PropsWithChildren<{}>) {

--- a/src/app/[lang]/(mods-pages)/shops/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/shops/layout.tsx
@@ -1,8 +1,28 @@
 import { PropsWithChildren } from 'react'
 import Fade from '@/components/Animation/Fade';
+import { Metadata } from 'next';
 
-export const metadata = {
-    title: '廠商 Shops'
+export const metadata: Metadata = {
+    title: '廠商 Shops',
+    description: '查詢國立清華大學校園廠商與商店資訊。Find shops and vendors on the NTHU campus.',
+    keywords: ['清大廠商', 'NTHU shops', '清大商店', 'NTHU campus stores', '清大餐廳'],
+    openGraph: {
+        title: '廠商 | NTHUMods',
+        description: '查詢國立清華大學校園廠商與商店資訊。',
+        url: 'https://nthumods.com/zh/shops',
+    },
+    twitter: {
+        card: 'summary',
+        title: '廠商 | NTHUMods',
+        description: '查詢國立清華大學校園廠商與商店資訊。',
+    },
+    alternates: {
+        canonical: 'https://nthumods.com/zh/shops',
+        languages: {
+            en: 'https://nthumods.com/en/shops',
+            zh: 'https://nthumods.com/zh/shops',
+        },
+    },
 }
 
 export default function ClientLayout({ children }: PropsWithChildren<{}>) {

--- a/src/app/[lang]/(mods-pages)/student/grades/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/student/grades/layout.tsx
@@ -1,8 +1,14 @@
 import { PropsWithChildren } from 'react'
 import Fade from '@/components/Animation/Fade';
+import { Metadata } from 'next';
 
-export const metadata = {
-    title: '個人成績 Grades'
+export const metadata: Metadata = {
+    title: '個人成績 Grades',
+    description: '查詢個人學業成績記錄。View your personal academic grade records.',
+    robots: {
+        index: false,
+        follow: false,
+    },
 }
 
 export default function ClientLayout({ children }: PropsWithChildren<{}>) {

--- a/src/app/[lang]/(mods-pages)/timetable/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/timetable/layout.tsx
@@ -1,8 +1,28 @@
 import Fade from '@/components/Animation/Fade'
+import { Metadata } from 'next'
 import { PropsWithChildren } from 'react'
 
-export const metadata = {
-    title: '時間表 Timetable'
+export const metadata: Metadata = {
+    title: '時間表 Timetable',
+    description: '規劃並管理您的國立清華大學課程時間表。Plan and manage your NTHU personal course timetable.',
+    keywords: ['清大課表', 'NTHU timetable', '清大時間表', 'NTHU schedule', '選課規劃', 'course planner'],
+    openGraph: {
+        title: '時間表 | NTHUMods',
+        description: '規劃並管理您的國立清華大學課程時間表。',
+        url: 'https://nthumods.com/zh/timetable',
+    },
+    twitter: {
+        card: 'summary',
+        title: '時間表 | NTHUMods',
+        description: '規劃並管理您的國立清華大學課程時間表。',
+    },
+    alternates: {
+        canonical: 'https://nthumods.com/zh/timetable',
+        languages: {
+            en: 'https://nthumods.com/en/timetable',
+            zh: 'https://nthumods.com/zh/timetable',
+        },
+    },
 }
 
 export default function ClientLayout({ children }: PropsWithChildren<{}>) {

--- a/src/app/[lang]/(mods-pages)/today/layout.tsx
+++ b/src/app/[lang]/(mods-pages)/today/layout.tsx
@@ -1,8 +1,28 @@
 import Fade from '@/components/Animation/Fade'
+import { Metadata } from 'next'
 import { PropsWithChildren } from 'react'
 
-export const metadata = {
-    title: '行事曆 Today'
+export const metadata: Metadata = {
+    title: '行事曆 Today',
+    description: '查看今日課表與校園行事曆，掌握當天活動與課程安排。View your daily NTHU class schedule and campus calendar.',
+    keywords: ['清大行事曆', 'NTHU today', '清大今日課表', 'NTHU daily schedule', '清大活動'],
+    openGraph: {
+        title: '行事曆 | NTHUMods',
+        description: '查看今日課表與校園行事曆，掌握當天活動與課程安排。',
+        url: 'https://nthumods.com/zh/today',
+    },
+    twitter: {
+        card: 'summary',
+        title: '行事曆 | NTHUMods',
+        description: '查看今日課表與校園行事曆，掌握當天活動與課程安排。',
+    },
+    alternates: {
+        canonical: 'https://nthumods.com/zh/today',
+        languages: {
+            en: 'https://nthumods.com/en/today',
+            zh: 'https://nthumods.com/zh/today',
+        },
+    },
 }
 
 export default function ClientLayout({ children }: PropsWithChildren<{}>) {

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -20,25 +20,34 @@ import AppUrlListener from '@/components/AppUrlListener';
 export const metadata: Metadata = {
   title: {
     template: '%s | NTHUMods',
-    default: 'NTHUMods',
+    default: 'NTHUMods - 國立清華大學課程資訊平臺',
   },
-  description: '國立清華大學課表、校車時間表、資料整合平臺，學生主導、學生自主開發。',
+  description: '國立清華大學課程查詢、課表規劃、校車時間表、地點查詢資料整合平臺。NTHU course search, timetable planner, and campus bus schedule — student-built.',
   applicationName: "NTHUMods",
   metadataBase: new URL("https://nthumods.com"),
   appleWebApp: {
     title: "NTHUMods",
     statusBarStyle: "black-translucent",
   },
-  robots: "index, follow",
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
   publisher: "@nthumodifications",
-  alternates:  {
-    canonical: "https://nthumods.com", 
-    languages: { 
+  alternates: {
+    canonical: "https://nthumods.com",
+    languages: {
       "en": "https://nthumods.com/en",
       "zh": "https://nthumods.com/zh"
     }
   },
-  category: "education, reference, courses, timetable, nthu, nthumods, nthumodifications, bus timetable",
+  category: "education",
   keywords: [
     "國立清華大學",
     "國立清華大學課程查詢",
@@ -61,20 +70,38 @@ export const metadata: Metadata = {
     "NTHU Bus Timetable",
     "NTHU Bus",
     "NTHU Bus Schedule",
-    "NTHU Bus Timetable",
-    "NTHU Student Developers"
+    "NTHU Student Developers",
+    "清華大學選課",
+    "清大選課系統",
   ],
   authors: { name: '@nthumodifications', url: 'https://github.com/nthumodifications' },
   creator: '@nthumodifications Team',
   openGraph: {
     type: 'website',
-    title: 'NTHUMods',
-    description: '清大課表、校車時間表、資料整合平臺，學生主導、學生自主開發。',
+    title: 'NTHUMods - 國立清華大學課程資訊平臺',
+    description: '清大課程查詢、課表規劃、校車時間表。NTHU course search, timetable planner, and campus bus schedule.',
     url: 'https://nthumods.com',
     siteName: 'NTHUMods',
     countryName: 'Taiwan',
-    locale: 'en, zh'
-  }
+    locale: 'zh_TW',
+    alternateLocale: 'en_US',
+    images: [
+      {
+        url: '/images/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'NTHUMods - 國立清華大學課程資訊平臺',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'NTHUMods - 國立清華大學課程資訊平臺',
+    description: '清大課程查詢、課表規劃、校車時間表。NTHU course search, timetable planner, and campus bus schedule.',
+    images: ['/images/og-image.png'],
+    creator: '@nthumodifications',
+    site: '@nthumodifications',
+  },
 }
 
 
@@ -110,6 +137,34 @@ export default function RootLayout({
 
   const theme = cookies().get("theme");
 
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'NTHUMods',
+    url: 'https://nthumods.com',
+    description: '國立清華大學課程查詢、課表規劃、校車時間表資料整合平臺。',
+    applicationCategory: 'EducationApplication',
+    operatingSystem: 'Any',
+    inLanguage: ['zh-TW', 'en'],
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'TWD',
+    },
+    author: {
+      '@type': 'Organization',
+      name: 'NTHUModifications',
+      url: 'https://github.com/nthumodifications',
+    },
+    provider: {
+      '@type': 'CollegeOrUniversity',
+      name: '國立清華大學',
+      alternateName: 'National Tsing Hua University',
+      url: 'https://www.nthu.edu.tw',
+      sameAs: 'https://en.wikipedia.org/wiki/National_Tsing_Hua_University',
+    },
+  }
+
   return (
     <CssVarsProvider defaultMode={(theme?.value as any) ?? 'light'}>
       <NextAuthProvider>
@@ -119,6 +174,12 @@ export default function RootLayout({
               <UserTimetableProvider>
                 <ModalProvider>
                   <html lang={params.lang} translate="no" className={`${theme?.value ?? ''} ${inter.variable} ${noto.variable}`} suppressHydrationWarning>
+                    <head>
+                      <script
+                        type="application/ld+json"
+                        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+                      />
+                    </head>
                     <body>
                       {children}
                       <AppUrlListener/>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -17,6 +17,10 @@ import ReactQuery from '@/components/ReactQuery';
 import './globals.css'
 import AppUrlListener from '@/components/AppUrlListener';
 
+export function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'zh' }]
+}
+
 export const metadata: Metadata = {
   title: {
     template: '%s | NTHUMods',
@@ -137,6 +141,23 @@ export default function RootLayout({
 
   const theme = cookies().get("theme");
 
+  const websiteJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'NTHUMods',
+    url: 'https://nthumods.com',
+    description: '國立清華大學課程查詢、課表規劃、校車時間表資料整合平臺。',
+    inLanguage: ['zh-TW', 'en'],
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: `https://nthumods.com/${params.lang}/courses?textSearch={search_term_string}`,
+      },
+      'query-input': 'required name=search_term_string',
+    },
+  }
+
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
@@ -175,6 +196,10 @@ export default function RootLayout({
                 <ModalProvider>
                   <html lang={params.lang} translate="no" className={`${theme?.value ?? ''} ${inter.variable} ${noto.variable}`} suppressHydrationWarning>
                     <head>
+                      <script
+                        type="application/ld+json"
+                        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+                      />
                       <script
                         type="application/ld+json"
                         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/api/',
+          '/zh/student/',
+          '/en/student/',
+          '/zh/cds/',
+          '/en/cds/',
+          '/zh/ais-redirect/',
+          '/en/ais-redirect/',
+        ],
+      },
+    ],
+    sitemap: 'https://nthumods.com/sitemap.xml',
+    host: 'https://nthumods.com',
+  }
+}

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Allow: /

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,63 +1,55 @@
 import { MetadataRoute } from 'next'
 import { stops, routes } from '@/const/bus'
+import { departments } from '@/const/departments'
+import { semesterInfo } from '@/const/semester'
+import supabase from '@/config/supabase'
 
 const BASE_URL = 'https://nthumods.com'
 const LANGS = ['en', 'zh'] as const
 const NOW = new Date()
 
 const staticPages = [
-  { path: '/today', priority: 1.0 },
-  { path: '/courses', priority: 0.9 },
-  { path: '/timetable', priority: 0.8 },
-  { path: '/venues', priority: 0.8 },
-  { path: '/bus', priority: 0.8 },
-  { path: '/shops', priority: 0.7 },
-  { path: '/apps', priority: 0.6 },
-  { path: '/settings', priority: 0.5 },
-  { path: '/team', priority: 0.4 },
-  { path: '/issues', priority: 0.4 },
-  { path: '/privacy-policy', priority: 0.3 },
+  { path: '/today', priority: 1.0, changeFreq: 'daily' as const },
+  { path: '/courses', priority: 0.9, changeFreq: 'daily' as const },
+  { path: '/timetable', priority: 0.8, changeFreq: 'weekly' as const },
+  { path: '/venues', priority: 0.8, changeFreq: 'weekly' as const },
+  { path: '/bus', priority: 0.8, changeFreq: 'daily' as const },
+  { path: '/shops', priority: 0.7, changeFreq: 'weekly' as const },
+  { path: '/apps', priority: 0.6, changeFreq: 'monthly' as const },
+  { path: '/settings', priority: 0.3, changeFreq: 'monthly' as const },
+  { path: '/team', priority: 0.4, changeFreq: 'monthly' as const },
+  { path: '/issues', priority: 0.4, changeFreq: 'weekly' as const },
+  { path: '/privacy-policy', priority: 0.3, changeFreq: 'yearly' as const },
 ]
 
-export default function sitemap(): MetadataRoute.Sitemap {
+const recentSemesterIds = new Set(semesterInfo.slice(-2).map(s => s.id))
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const entries: MetadataRoute.Sitemap = []
 
-  // Static pages for each language
+  // Static pages — both languages
   for (const page of staticPages) {
-    entries.push({
-      url: `${BASE_URL}/zh${page.path}`,
-      lastModified: NOW,
-      changeFrequency: page.priority >= 0.9 ? 'daily' : page.priority >= 0.7 ? 'weekly' : 'monthly',
-      priority: page.priority,
-      alternates: {
-        languages: {
-          en: `${BASE_URL}/en${page.path}`,
-          zh: `${BASE_URL}/zh${page.path}`,
+    for (const lang of LANGS) {
+      entries.push({
+        url: `${BASE_URL}/${lang}${page.path}`,
+        lastModified: NOW,
+        changeFrequency: page.changeFreq,
+        priority: page.priority,
+        alternates: {
+          languages: {
+            en: `${BASE_URL}/en${page.path}`,
+            zh: `${BASE_URL}/zh${page.path}`,
+          },
         },
-      },
-    })
-    entries.push({
-      url: `${BASE_URL}/en${page.path}`,
-      lastModified: NOW,
-      changeFrequency: page.priority >= 0.9 ? 'daily' : page.priority >= 0.7 ? 'weekly' : 'monthly',
-      priority: page.priority,
-      alternates: {
-        languages: {
-          en: `${BASE_URL}/en${page.path}`,
-          zh: `${BASE_URL}/zh${page.path}`,
-        },
-      },
-    })
-  }
-
-  // Bus stop pages - derive all stop IDs from routes
-  const allStopIds = new Set<string>()
-  for (const route of routes) {
-    for (const stopId of route.path) {
-      allStopIds.add(stopId)
+      })
     }
   }
 
+  // Bus stops — derived from routes constants
+  const allStopIds = new Set<string>()
+  for (const route of routes) {
+    for (const stopId of route.path) allStopIds.add(stopId)
+  }
   for (const stopId of allStopIds) {
     for (const lang of LANGS) {
       entries.push({
@@ -73,6 +65,56 @@ export default function sitemap(): MetadataRoute.Sitemap {
         },
       })
     }
+  }
+
+  // Department index pages
+  for (const dept of departments) {
+    for (const lang of LANGS) {
+      entries.push({
+        url: `${BASE_URL}/${lang}/courses/dept/${dept.code}`,
+        lastModified: NOW,
+        changeFrequency: 'weekly',
+        priority: 0.7,
+        alternates: {
+          languages: {
+            en: `${BASE_URL}/en/courses/dept/${dept.code}`,
+            zh: `${BASE_URL}/zh/courses/dept/${dept.code}`,
+          },
+        },
+      })
+    }
+  }
+
+  // All course detail pages — fetched from Supabase
+  // Recent semesters get higher priority; older ones are still indexed
+  try {
+    const { data: courses } = await supabase
+      .from('courses')
+      .select('raw_id, semester')
+      .order('semester', { ascending: false })
+
+    if (courses) {
+      for (const course of courses) {
+        const isRecent = recentSemesterIds.has(course.semester)
+        const courseEncoded = encodeURIComponent(course.raw_id)
+        for (const lang of LANGS) {
+          entries.push({
+            url: `${BASE_URL}/${lang}/courses/${courseEncoded}`,
+            lastModified: NOW,
+            changeFrequency: isRecent ? 'monthly' : 'yearly',
+            priority: isRecent ? 0.8 : 0.5,
+            alternates: {
+              languages: {
+                en: `${BASE_URL}/en/courses/${courseEncoded}`,
+                zh: `${BASE_URL}/zh/courses/${courseEncoded}`,
+              },
+            },
+          })
+        }
+      }
+    }
+  } catch {
+    // Sitemap degrades gracefully if DB is unreachable
   }
 
   return entries

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,79 @@
+import { MetadataRoute } from 'next'
+import { stops, routes } from '@/const/bus'
+
+const BASE_URL = 'https://nthumods.com'
+const LANGS = ['en', 'zh'] as const
+const NOW = new Date()
+
+const staticPages = [
+  { path: '/today', priority: 1.0 },
+  { path: '/courses', priority: 0.9 },
+  { path: '/timetable', priority: 0.8 },
+  { path: '/venues', priority: 0.8 },
+  { path: '/bus', priority: 0.8 },
+  { path: '/shops', priority: 0.7 },
+  { path: '/apps', priority: 0.6 },
+  { path: '/settings', priority: 0.5 },
+  { path: '/team', priority: 0.4 },
+  { path: '/issues', priority: 0.4 },
+  { path: '/privacy-policy', priority: 0.3 },
+]
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = []
+
+  // Static pages for each language
+  for (const page of staticPages) {
+    entries.push({
+      url: `${BASE_URL}/zh${page.path}`,
+      lastModified: NOW,
+      changeFrequency: page.priority >= 0.9 ? 'daily' : page.priority >= 0.7 ? 'weekly' : 'monthly',
+      priority: page.priority,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/en${page.path}`,
+          zh: `${BASE_URL}/zh${page.path}`,
+        },
+      },
+    })
+    entries.push({
+      url: `${BASE_URL}/en${page.path}`,
+      lastModified: NOW,
+      changeFrequency: page.priority >= 0.9 ? 'daily' : page.priority >= 0.7 ? 'weekly' : 'monthly',
+      priority: page.priority,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/en${page.path}`,
+          zh: `${BASE_URL}/zh${page.path}`,
+        },
+      },
+    })
+  }
+
+  // Bus stop pages - derive all stop IDs from routes
+  const allStopIds = new Set<string>()
+  for (const route of routes) {
+    for (const stopId of route.path) {
+      allStopIds.add(stopId)
+    }
+  }
+
+  for (const stopId of allStopIds) {
+    for (const lang of LANGS) {
+      entries.push({
+        url: `${BASE_URL}/${lang}/bus/stop/${stopId}`,
+        lastModified: NOW,
+        changeFrequency: 'weekly',
+        priority: 0.6,
+        alternates: {
+          languages: {
+            en: `${BASE_URL}/en/bus/stop/${stopId}`,
+            zh: `${BASE_URL}/zh/bus/stop/${stopId}`,
+          },
+        },
+      })
+    }
+  }
+
+  return entries
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+type JsonLdProps = {
+    data: Record<string, unknown>
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+        />
+    )
+}


### PR DESCRIPTION
## Summary
This PR significantly enhances SEO across the NTHUMods platform by adding comprehensive metadata, generating a dynamic sitemap, implementing structured data (JSON-LD), and creating new department-specific course listing pages.

## Key Changes

### New Pages & Routes
- **Department course listing page** (`src/app/[lang]/(mods-pages)/courses/dept/[department]/page.tsx`): New page that displays all courses for a specific department, grouped by semester with links to course details
- **Bus stop layout metadata** (`src/app/[lang]/(mods-pages)/bus/stop/[stopId]/layout.tsx`): Added metadata generation for individual bus stop pages

### SEO Infrastructure
- **Dynamic sitemap** (`src/app/sitemap.ts`): Generates comprehensive sitemap with all static pages, departments, bus stops, and courses from the database, with appropriate priority and change frequency settings
- **Robots.txt** (`src/app/robots.ts`): Replaces static robots.txt with dynamic configuration, disallowing API routes and student-specific pages while allowing public content
- **JSON-LD structured data** (`src/components/JsonLd.tsx`): New reusable component for embedding structured data
  - Root layout includes WebSite and WebApplication schema
  - Course detail pages include BreadcrumbList and Course schema
  - Department pages include BreadcrumbList and ItemList schema
  - Course detail pages include BreadcrumbList and Course schema

### Enhanced Metadata
- **Root layout** (`src/app/[lang]/layout.tsx`): 
  - Added `generateStaticParams()` for language routes
  - Expanded metadata with better descriptions, keywords, and Open Graph/Twitter cards
  - Added JSON-LD structured data for website and web application
  - Improved robots configuration with googleBot-specific settings
  - Added og:image and twitter:image references

- **Page-specific metadata** across multiple layout files:
  - Courses, Timetable, Today, Bus, Venues, Shops, Settings, and Grades pages now have comprehensive metadata with descriptions, keywords, and language alternates
  - Settings and Grades pages marked as non-indexable (`robots: { index: false }`)

- **Course detail page** (`src/app/[lang]/(mods-pages)/courses/[courseId]/page.tsx`):
  - Added static generation for recent semester courses
  - Enhanced metadata with keywords, Open Graph, and Twitter cards
  - Added breadcrumb and course schema JSON-LD
  - Improved canonical URL handling with language alternates

- **Venue detail page** (`src/app/[lang]/(mods-pages)/(venues)/venues/@content/[locationId]/page.tsx`):
  - Added comprehensive metadata with descriptions and canonical URLs

## Notable Implementation Details
- Department pages use `generateStaticParams()` to pre-render all department routes at build time
- Course detail pages use `dynamicParams: true` to allow on-demand rendering for courses not in the latest semester
- Sitemap prioritizes recent semester courses (0.8) over older ones (0.5)
- All pages include language alternates for SEO best practices
- Breadcrumb schema implemented consistently across course and department pages for improved search result appearance

https://claude.ai/code/session_01GnzujNB7Y8h7u9Qy9imrvc