### PR TITLE
fix(data-sync): fix scraper not running in Bun ESM + add manual trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      semester:
+        description: "Semester to sync (e.g. 11510)"
+        required: false
+        default: "11510"
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
@@ -138,6 +144,32 @@ jobs:
   #         curl --request GET "${{ secrets.COOLIFY_WEBHOOK }}" \
   #           --header "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}"
   #       if: success()
+
+  run-scraper:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run course scraper
+        working-directory: tools/data-sync
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          SEMESTER: ${{ github.event.inputs.semester || '11510' }}
+        run: bun run src/sync-courses.ts ${{ github.event.inputs.semester || '11510' }}
 
   build-and-push-data-sync:
     runs-on: ubuntu-latest

--- a/tools/data-sync/run-docker.sh
+++ b/tools/data-sync/run-docker.sh
@@ -158,9 +158,9 @@ fi
 
 # Set command based on mode
 if [[ "$MODE" == "once" ]]; then
-    CMD="tsx src/sync-courses.ts $SEMESTER"
+    CMD="bun run src/sync-courses.ts $SEMESTER"
 else
-    CMD="tsx src/update-courses.ts \"$CRON_PATTERN\" $SEMESTER"
+    CMD="bun run src/update-courses.ts \"$CRON_PATTERN\" $SEMESTER"
 fi
 
 # Run container

--- a/tools/data-sync/src/sync-courses.ts
+++ b/tools/data-sync/src/sync-courses.ts
@@ -65,7 +65,7 @@ export const syncCourses = async (
 export default syncCourses;
 
 // If this file is run directly, execute the sync
-if (require.main === module) {
+if (import.meta.main) {
   const semester = process.argv[2] || "11510";
   console.log(`Running sync for semester: ${semester}`);
 

--- a/tools/data-sync/src/update-courses.ts
+++ b/tools/data-sync/src/update-courses.ts
@@ -107,7 +107,7 @@ export { syncCourseData };
 export default startScheduledSync;
 
 // If this file is run directly, start the scheduled sync
-if (require.main === module) {
+if (import.meta.main) {
   const cronPattern = process.argv[2] || "0 0 * * *";
   const semester = process.argv[3] || "11510";
 


### PR DESCRIPTION
- Replace `require.main === module` with `import.meta.main` in both
  sync-courses.ts and update-courses.ts — the old check doesn't work in
  Bun ESM (module: esnext), causing the Docker container to exit silently
  without ever running the scraper
- Fix run-docker.sh to use `bun run` instead of `tsx` (tsx is not
  installed in the container)
- Add workflow_dispatch trigger to build.yaml with a run-scraper job so
  the scraper can be manually triggered from the GitHub Actions UI
  with a configurable semester parameter

https://claude.ai/code/session_01RbmtUdLaaURBWLK2BrXfok