### PR TITLE
Fix duplicate timetable sync requests and race conditions

### DIFF
--- a/apps/web/src/components/Calendar/Calendar.tsx
+++ b/apps/web/src/components/Calendar/Calendar.tsx
@@ -65,7 +65,7 @@ const Calendar = () => {
     HOUR_HEIGHT,
     timetableSyncReady,
   } = useCalendar();
-  const { courses, colorMap, getSemesterCourses } = useUserTimetable();
+  const { courses, colorMap, getSemesterCourses, isLoading: coursesLoading } = useUserTimetable();
   const { language } = useSettings();
   const isMobile = useIsMobile();
   const dict = useDictionary();
@@ -255,7 +255,7 @@ const Calendar = () => {
   );
 
   const syncTimetable = async () => {
-    if (!timetableSync || !timetableSyncReady || Object.keys(courses).length === 0) return;
+    if (!timetableSync || !timetableSyncReady || coursesLoading || Object.keys(courses).length === 0) return;
 
     // for each semester, check if its already synced
     const timetableCourses: TimetableSyncRequest[] = [];
@@ -301,10 +301,10 @@ const Calendar = () => {
   };
 
   useEffect(() => {
-    if (timetableSyncReady) {
+    if (timetableSyncReady && !coursesLoading) {
       syncTimetable();
     }
-  }, [courses, timetableSync, timetableSyncReady]);
+  }, [courses, timetableSync, timetableSyncReady, coursesLoading]);
 
   const handleSyncAccept = async (
     request: TimetableSyncRequest,

--- a/apps/web/src/components/Calendar/CalendarTimetableSyncDialog.tsx
+++ b/apps/web/src/components/Calendar/CalendarTimetableSyncDialog.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,24 +17,22 @@ const CalendarTimetableSyncDialog: FC<{
   onSyncAccept: (request: TimetableSyncRequest, accept: boolean) => void;
 }> = ({ request, onSyncAccept }) => {
   const [open, setOpen] = useState(true);
+  const handledRef = useRef(false);
+
   useEffect(() => {
     setOpen(true);
+    handledRef.current = false;
   }, [request]);
 
-  const handleUserClose = () => {
-    if (open) {
-      setOpen(false);
-      onSyncAccept(request, false);
-    }
-  };
-
-  const handleUserSync = () => {
+  const handleClose = (accept: boolean) => {
+    if (handledRef.current) return;
+    handledRef.current = true;
     setOpen(false);
-    onSyncAccept(request, true);
+    onSyncAccept(request, accept);
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog open={open} onOpenChange={(isOpen) => { if (!isOpen) handleClose(false); }}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Timetable Update Found!</AlertDialogTitle>
@@ -45,10 +43,10 @@ const CalendarTimetableSyncDialog: FC<{
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={handleUserClose}>
+          <AlertDialogCancel onClick={() => handleClose(false)}>
             Cancel
           </AlertDialogCancel>
-          <AlertDialogAction onClick={handleUserSync}>Sync</AlertDialogAction>
+          <AlertDialogAction onClick={() => handleClose(true)}>Sync</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/services/secure-api/src/nthuoauth/__tests__/nthuAuth.test.ts
+++ b/services/secure-api/src/nthuoauth/__tests__/nthuAuth.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
+import { describe, expect, it, mock, beforeEach, afterEach, afterAll } from "bun:test";
 import nthuAuth from "../nthuAuth";
 import { setCookie } from "hono/cookie";
 import { HTTPException } from "hono/http-exception";
+import { AuthFlow as _RealAuthFlow } from "../authFlow";
 
 // Mock dependencies
 mock.module("hono/cookie", () => ({
@@ -78,6 +79,13 @@ describe("nthuAuth middleware", () => {
   afterEach(() => {
     // Clean up mocks
     mock.restore();
+  });
+
+  afterAll(() => {
+    // Bun's mock.restore() does not always clean up mock.module() between test
+    // files. Explicitly restore the real AuthFlow so authFlow.test.ts (and any
+    // other subsequent file) gets the real implementation.
+    mock.module("../authFlow", () => ({ AuthFlow: _RealAuthFlow }));
   });
 
   it("should redirect to login if no code is provided", async () => {

--- a/services/secure-api/src/nthuoauth/__tests__/nthuAuth.test.ts
+++ b/services/secure-api/src/nthuoauth/__tests__/nthuAuth.test.ts
@@ -3,6 +3,9 @@ import nthuAuth from "../nthuAuth";
 import { setCookie } from "hono/cookie";
 import { HTTPException } from "hono/http-exception";
 import { AuthFlow as _RealAuthFlow } from "../authFlow";
+// Capture the real class value NOW (module evaluation time) before any
+// mock.module() call can update the live ESM binding.
+const _realAuthFlow = _RealAuthFlow;
 
 // Mock dependencies
 mock.module("hono/cookie", () => ({
@@ -79,13 +82,16 @@ describe("nthuAuth middleware", () => {
   afterEach(() => {
     // Clean up mocks
     mock.restore();
+    // mock.restore() does NOT clean up mock.module() registrations in Bun 1.x.
+    // Explicitly restore so the next test (same file or next file) sees the
+    // real AuthFlow, not the mock.
+    mock.module("../authFlow", () => ({ AuthFlow: _realAuthFlow }));
   });
 
   afterAll(() => {
-    // Bun's mock.restore() does not always clean up mock.module() between test
-    // files. Explicitly restore the real AuthFlow so authFlow.test.ts (and any
-    // other subsequent file) gets the real implementation.
-    mock.module("../authFlow", () => ({ AuthFlow: _RealAuthFlow }));
+    // Belt-and-suspenders: ensure the registry is clean after this entire
+    // describe block so authFlow.test.ts gets the real implementation.
+    mock.module("../authFlow", () => ({ AuthFlow: _realAuthFlow }));
   });
 
   it("should redirect to login if no code is provided", async () => {


### PR DESCRIPTION
## Summary
This PR fixes issues with duplicate timetable sync requests and race conditions in the calendar timetable synchronization flow.

## Key Changes

- **CalendarTimetableSyncDialog.tsx**:
  - Added `useRef` hook to track whether a sync request has already been handled, preventing duplicate callbacks
  - Consolidated `handleUserClose` and `handleUserSync` into a single `handleClose(accept: boolean)` function
  - Updated `AlertDialog` `onOpenChange` handler to only trigger close logic when dialog is closing (not opening)
  - Refactored button click handlers to use the unified `handleClose` function

- **Calendar.tsx**:
  - Added `coursesLoading` state from `useUserTimetable` hook to track course loading status
  - Updated `syncTimetable` function to skip sync if courses are still loading
  - Modified `useEffect` dependency array to include `coursesLoading` and added condition to prevent sync while courses are loading

## Implementation Details

The main issue was that the dialog could trigger the `onSyncAccept` callback multiple times due to:
1. Both the dialog's `onOpenChange` handler and button click handlers calling sync logic
2. Race conditions when courses were still loading during sync initialization

The fix uses a ref-based guard (`handledRef`) to ensure each sync request is only processed once, and adds proper loading state checks to prevent syncing before data is ready.

https://claude.ai/code/session_018Qa9oocUM5CobdzUckeNyp