### PR TITLE
feat(course-dates): add user-submitted course dates with calendar int…

### DIFF
--- a/apps/web/src/components/Calendar/CalendarMonthContainer.tsx
+++ b/apps/web/src/components/Calendar/CalendarMonthContainer.tsx
@@ -16,11 +16,13 @@ import { eventsToDisplay } from "@/components/Calendar/calendar_utils";
 import { getContrastColor, getBrightness } from "@/helpers/colors";
 import { EventPopover } from "./EventPopover";
 import { useMediaQuery } from "usehooks-ts";
-import { Fragment, useCallback } from "react";
+import { Fragment, useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { CalendarEventInternal } from "@/components/Calendar/calendar.types";
 import { useSettings } from "@/hooks/contexts/settings";
 import client from "@/config/api";
+import useUserTimetable from "@/hooks/contexts/useUserTimetable";
+import useCourseDates from "@/hooks/useCourseDates";
 
 export const CalendarMonthContainer = ({
   displayMonth,
@@ -31,6 +33,12 @@ export const CalendarMonthContainer = ({
 }) => {
   const { events } = useCalendar();
   const { showAcademicCalendar } = useSettings();
+  const { courses } = useUserTimetable();
+  const enrolledCourseIds = useMemo(
+    () => Object.values(courses).flat(),
+    [courses],
+  );
+  const { getCourseDateForDay } = useCourseDates(enrolledCourseIds);
 
   const isScreenMD = useMediaQuery("(min-width: 768px)");
   const rows_length = Math.ceil(displayMonth.length / 7);
@@ -76,11 +84,13 @@ export const CalendarMonthContainer = ({
         startOfDay(day),
         endOfDay(day),
       ).map((event) => {
-        // Determine the text color
+        const courseDate = event.courseId
+          ? getCourseDateForDay(event.courseId, day)
+          : null;
+        const isNoClass = courseDate?.type === "no_class";
         const brightness = getBrightness(event.color);
-        // From the brightness, using the getContrastColor function, create a complementary color that is legible
-        const textColor = getContrastColor(event.color);
-        return { ...event, textColor };
+        const textColor = isNoClass ? "#fff" : getContrastColor(event.color);
+        return { ...event, textColor, courseDate, isNoClass };
       });
 
       // Group overlapping events
@@ -127,17 +137,21 @@ export const CalendarMonthContainer = ({
           {allSortedEvents.map((event, index) => (
             <EventPopover key={index} event={event}>
               <div
-                className="bg-nthu-500 rounded-md p-0.5 md:p-1 flex flex-row gap-1 items-center hover:shadow-md cursor-pointer transition-shadow select-none"
+                className="rounded-md p-0.5 md:p-1 flex flex-row gap-1 items-center hover:shadow-md cursor-pointer transition-shadow select-none"
                 style={{
-                  background: event.color,
+                  background: event.isNoClass
+                    ? "repeating-linear-gradient(-45deg, #9ca3af, #9ca3af 4px, #6b7280 4px, #6b7280 8px)"
+                    : event.color,
                   color: event.textColor,
                   height: isScreenMD ? 20 : 16,
                   width: "100%",
                 }}
               >
-                <div className="hidden md:inline text-[10px] font-normal leading-none">
-                  {format(event.displayStart, "HH:mm")}
-                </div>
+                {!event.isNoClass && (
+                  <div className="hidden md:inline text-[10px] font-normal leading-none">
+                    {format(event.displayStart, "HH:mm")}
+                  </div>
+                )}
                 <div className="text-xs leading-none whitespace-nowrap overflow-hidden">
                   {event.title}
                 </div>
@@ -147,7 +161,7 @@ export const CalendarMonthContainer = ({
         </div>
       );
     },
-    [events, isScreenMD],
+    [events, isScreenMD, getCourseDateForDay],
   );
 
   const renderAllDayEvents = useCallback(

--- a/apps/web/src/components/Calendar/CalendarWeekContainer.tsx
+++ b/apps/web/src/components/Calendar/CalendarWeekContainer.tsx
@@ -30,6 +30,8 @@ import { useSettings } from "@/hooks/contexts/settings";
 import client from "@/config/api";
 import { AddEventButton } from "./AddEventButton";
 import { getNearestTime } from "@courseweb/ui";
+import useUserTimetable from "@/hooks/contexts/useUserTimetable";
+import useCourseDates from "@/hooks/useCourseDates";
 
 export const CalendarWeekContainer = ({
   displayWeek,
@@ -38,6 +40,12 @@ export const CalendarWeekContainer = ({
 }) => {
   const { events, addEvent, displayContainer, HOUR_HEIGHT } = useCalendar();
   const { showAcademicCalendar } = useSettings();
+  const { courses } = useUserTimetable();
+  const enrolledCourseIds = useMemo(
+    () => Object.values(courses).flat(),
+    [courses],
+  );
+  const { getCourseDateForDay } = useCourseDates(enrolledCourseIds);
   const [eventFormOpen, setEventFormOpen] = useState(false);
   const [newEventTime, setNewEventTime] = useState<Date | null>(null);
 
@@ -194,8 +202,22 @@ export const CalendarWeekContainer = ({
           (heightMs / (1000 * 60 * 60)) * HOUR_HEIGHT,
         );
 
+        const courseDate = event.courseId
+          ? getCourseDateForDay(event.courseId, day)
+          : null;
+        const isNoClass = courseDate?.type === "no_class";
+        const isSpecialDate = courseDate && !isNoClass;
+
+        const eventBackground = isNoClass
+          ? "repeating-linear-gradient(-45deg, #9ca3af, #9ca3af 4px, #6b7280 4px, #6b7280 8px)"
+          : event.color;
+        const eventTextColor = isNoClass ? "#fff" : event.textColor;
+
         return (
-          <EventPopover key={`${event.id}-${event.displayStart.getTime()}`} event={event}>
+          <EventPopover
+            key={`${event.id}-${event.displayStart.getTime()}`}
+            event={event}
+          >
             <div
               className="absolute pr-0.5 event-item"
               style={{
@@ -208,8 +230,8 @@ export const CalendarWeekContainer = ({
               }}
             >
               <div
-                className="overflow-hidden rounded-md h-full p-1 flex flex-col gap-1 hover:shadow-md cursor-pointer transition-shadow select-none"
-                style={{ background: event.color, color: event.textColor }}
+                className="relative overflow-hidden rounded-md h-full p-1 flex flex-col gap-1 hover:shadow-md cursor-pointer transition-shadow select-none"
+                style={{ background: eventBackground, color: eventTextColor }}
               >
                 <div className="text-xs leading-none">{event.title}</div>
                 <div className="text-xs font-normal leading-none">
@@ -219,13 +241,18 @@ export const CalendarWeekContainer = ({
                 {event.location && (
                   <div className="text-xs leading-none">{event.location}</div>
                 )}
+                {isSpecialDate && (
+                  <div className="text-[9px] leading-none font-semibold uppercase opacity-90 bg-black/20 rounded px-1 py-0.5 self-start">
+                    {courseDate.type}
+                  </div>
+                )}
               </div>
             </div>
           </EventPopover>
         );
       });
     },
-    [events, HOUR_HEIGHT],
+    [events, HOUR_HEIGHT, getCourseDateForDay],
   );
   const dayEvents = useMemo(() => {
     // Step 1: Prepare events with display information

--- a/apps/web/src/components/Calendar/EventPopover.tsx
+++ b/apps/web/src/components/Calendar/EventPopover.tsx
@@ -3,9 +3,19 @@ import { FC, PropsWithChildren, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@courseweb/ui";
 import { CalendarEvent, DisplayCalendarEvent } from "./calendar.types";
 import { Button } from "@courseweb/ui";
-import { Delete, Edit, MapPin, Pin, Text, Trash, X } from "lucide-react";
+import {
+  Delete,
+  Edit,
+  MapPin,
+  Pin,
+  Text,
+  Trash,
+  X,
+  CalendarPlus,
+} from "lucide-react";
 import { PopoverClose } from "@radix-ui/react-popover";
 import { UpdateType, useCalendar } from "./calendar_hook";
+import DateContributeForm from "@/components/CourseDetails/DateContributeForm";
 import {
   Dialog,
   DialogContent,
@@ -161,6 +171,13 @@ export const EventPopover: FC<
         />
         <div className="flex flex-col">
           <div className="flex flex-row justify-end">
+            {event.courseId && (
+              <DateContributeForm courseId={event.courseId}>
+                <Button size="icon" variant="ghost">
+                  <CalendarPlus className="w-4 h-4" />
+                </Button>
+              </DateContributeForm>
+            )}
             {!event.readonly && (
               <AddEventButton
                 defaultEvent={{

--- a/apps/web/src/components/Calendar/calendar.types.ts
+++ b/apps/web/src/components/Calendar/calendar.types.ts
@@ -17,6 +17,7 @@ export interface CalendarEvent {
   repeat: null | RepeatDefinition;
   color: string;
   tag: string | "none";
+  courseId?: string;
   excludedDates?: Date[];
   parentId?: string;
   readonly?: boolean;

--- a/apps/web/src/components/Calendar/timetableToCalendarEvent.tsx
+++ b/apps/web/src/components/Calendar/timetableToCalendarEvent.tsx
@@ -53,6 +53,7 @@ export const timetableToCalendarEvent = (
         },
         color: t.color,
         tag: "course",
+        courseId: t.course.raw_id,
       };
     });
 };

--- a/apps/web/src/components/CourseDetails/DateContributeForm.tsx
+++ b/apps/web/src/components/CourseDetails/DateContributeForm.tsx
@@ -37,6 +37,8 @@ import { toast } from "@courseweb/ui";
 import { Dialog, DialogContent, DialogTrigger } from "@courseweb/ui";
 import useDictionary from "@/dictionaries/useDictionary";
 import client from "@/config/api";
+import authClient from "@/config/auth";
+import { useAuth } from "react-oidc-context";
 
 const schema = z.object({
   dates: z.array(
@@ -59,6 +61,7 @@ const DateContributeForm = ({
 }: PropsWithChildren<{ courseId: string }>) => {
   const [open, setOpen] = useState(false);
   const dict = useDictionary();
+  const auth = useAuth();
   const {
     data: existingDates,
     error,
@@ -114,21 +117,17 @@ const DateContributeForm = ({
       date: format(d.date, "yyyy-MM-dd"),
     }));
 
-    // const result = await submitContribDates(ACIXSTORE, courseId, submitDates);
-    const res = await client.course[":courseId"].dates.$post({
-      json: {
-        dates: submitDates,
-      },
+    const res = await authClient.api["course-dates"][":courseId"].$post({
+      json: { dates: submitDates },
       param: { courseId },
     });
-    const result = await res.json();
-    // if (typeof result == "object" && "error" in result) {
-    //   toast({
-    //     title: "Failed to submit",
-    //     description: result.error.message,
-    //   });
-    //   throw new Error(result.error.message);
-    // }
+    if (!res.ok) {
+      toast({
+        title: "Failed to submit",
+        variant: "destructive",
+      });
+      return;
+    }
     toast({
       title: "Submitted successfully",
       description: "Your contribution has been submitted successfully",
@@ -144,167 +143,182 @@ const DateContributeForm = ({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1">
-            <h1 className="text-2xl font-bold">
-              {dict.dialogs.DateContributeForm.title}
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              {dict.dialogs.DateContributeForm.description}
+        {!auth.isAuthenticated ? (
+          <div className="flex flex-col gap-4 items-center py-8">
+            <CalendarPlus className="w-10 h-10 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground text-center">
+              {dict.dialogs.DateContributeForm.sign_in_required}
             </p>
+            <Button onClick={() => auth.signinRedirect()}>
+              {dict.auth?.sign_in ?? "Sign in"}
+            </Button>
           </div>
-          <Alert>
-            <Edit2 className="h-4 w-4" />
-            <AlertTitle>
-              {dict.dialogs.DateContributeForm.dont_abuse}
-            </AlertTitle>
-            <AlertDescription>
-              <p>{dict.dialogs.DateContributeForm.accurate_relavent}</p>
-              <p>{dict.dialogs.DateContributeForm.disclaimer}</p>
-            </AlertDescription>
-          </Alert>
-          <ScrollArea>
-            <Form {...form}>
-              <div className="flex flex-col gap-2">
-                {fields.map((field, index) => (
-                  <div key={field.id} className="flex flex-row gap-2">
-                    <FormField
-                      control={form.control}
-                      name={`dates.${index}.type`}
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormControl>
-                            <Select
-                              defaultValue={field.value}
-                              value={field.value}
-                              onValueChange={field.onChange}
-                              disabled={disabled}
-                            >
-                              <SelectTrigger className="w-[90px]">
-                                <SelectValue placeholder="Type" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="exam">
-                                  {dict.dialogs.DateContributeForm.types.exam}
-                                </SelectItem>
-                                <SelectItem value="quiz">
-                                  {dict.dialogs.DateContributeForm.types.quiz}
-                                </SelectItem>
-                                <SelectItem value="no_class">
-                                  {
-                                    dict.dialogs.DateContributeForm.types
-                                      .no_class
-                                  }
-                                </SelectItem>
-                                <SelectItem value="other">
-                                  {dict.dialogs.DateContributeForm.types.other}
-                                </SelectItem>
-                              </SelectContent>
-                            </Select>
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name={`dates.${index}.title`}
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormControl>
-                            <Input
-                              autoComplete="off"
-                              placeholder="Title"
-                              disabled={disabled}
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name={`dates.${index}.date`}
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormControl>
-                            <Popover modal={true}>
-                              <PopoverTrigger asChild disabled={disabled}>
-                                <Button
-                                  variant={"outline"}
-                                  className={cn(
-                                    "w-[180px] justify-start text-left font-normal",
-                                    !field.value && "text-muted-foreground",
-                                  )}
-                                >
-                                  <CalendarIcon className="mr-2 h-4 w-4" />
-                                  {field.value ? (
-                                    format(field.value, "PPP")
-                                  ) : (
-                                    <span>
-                                      {
-                                        dict.dialogs.DateContributeForm
-                                          .date_placeholder
-                                      }
-                                    </span>
-                                  )}
-                                </Button>
-                              </PopoverTrigger>
-                              <PopoverContent className="w-auto p-0">
-                                <Calendar
-                                  mode="single"
-                                  selected={field.value}
-                                  onSelect={field.onChange}
-                                  initialFocus
-                                />
-                              </PopoverContent>
-                            </Popover>
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <Button
-                      variant="destructive"
-                      size="icon"
-                      disabled={disabled}
-                      onClick={() => remove(index)}
-                    >
-                      <MinusCircle className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-                <Button
-                  variant={"outline"}
-                  disabled={disabled}
-                  onClick={() =>
-                    append({ type: "exam", title: "", date: new Date() })
-                  }
-                >
-                  <Plus className="mr-2" />{" "}
-                  {dict.dialogs.DateContributeForm.add_date}
-                </Button>
-                <div className="flex flex-row gap-2 justify-end">
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <h1 className="text-2xl font-bold">
+                {dict.dialogs.DateContributeForm.title}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                {dict.dialogs.DateContributeForm.description}
+              </p>
+            </div>
+            <Alert>
+              <Edit2 className="h-4 w-4" />
+              <AlertTitle>
+                {dict.dialogs.DateContributeForm.dont_abuse}
+              </AlertTitle>
+              <AlertDescription>
+                <p>{dict.dialogs.DateContributeForm.accurate_relavent}</p>
+                <p>{dict.dialogs.DateContributeForm.disclaimer}</p>
+              </AlertDescription>
+            </Alert>
+            <ScrollArea>
+              <Form {...form}>
+                <div className="flex flex-col gap-2">
+                  {fields.map((field, index) => (
+                    <div key={field.id} className="flex flex-row gap-2">
+                      <FormField
+                        control={form.control}
+                        name={`dates.${index}.type`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormControl>
+                              <Select
+                                defaultValue={field.value}
+                                value={field.value}
+                                onValueChange={field.onChange}
+                                disabled={disabled}
+                              >
+                                <SelectTrigger className="w-[90px]">
+                                  <SelectValue placeholder="Type" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="exam">
+                                    {dict.dialogs.DateContributeForm.types.exam}
+                                  </SelectItem>
+                                  <SelectItem value="quiz">
+                                    {dict.dialogs.DateContributeForm.types.quiz}
+                                  </SelectItem>
+                                  <SelectItem value="no_class">
+                                    {
+                                      dict.dialogs.DateContributeForm.types
+                                        .no_class
+                                    }
+                                  </SelectItem>
+                                  <SelectItem value="other">
+                                    {
+                                      dict.dialogs.DateContributeForm.types
+                                        .other
+                                    }
+                                  </SelectItem>
+                                </SelectContent>
+                              </Select>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name={`dates.${index}.title`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormControl>
+                              <Input
+                                autoComplete="off"
+                                placeholder="Title"
+                                disabled={disabled}
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name={`dates.${index}.date`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormControl>
+                              <Popover modal={true}>
+                                <PopoverTrigger asChild disabled={disabled}>
+                                  <Button
+                                    variant={"outline"}
+                                    className={cn(
+                                      "w-[180px] justify-start text-left font-normal",
+                                      !field.value && "text-muted-foreground",
+                                    )}
+                                  >
+                                    <CalendarIcon className="mr-2 h-4 w-4" />
+                                    {field.value ? (
+                                      format(field.value, "PPP")
+                                    ) : (
+                                      <span>
+                                        {
+                                          dict.dialogs.DateContributeForm
+                                            .date_placeholder
+                                        }
+                                      </span>
+                                    )}
+                                  </Button>
+                                </PopoverTrigger>
+                                <PopoverContent className="w-auto p-0">
+                                  <Calendar
+                                    mode="single"
+                                    selected={field.value}
+                                    onSelect={field.onChange}
+                                    initialFocus
+                                  />
+                                </PopoverContent>
+                              </Popover>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <Button
+                        variant="destructive"
+                        size="icon"
+                        disabled={disabled}
+                        onClick={() => remove(index)}
+                      >
+                        <MinusCircle className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  ))}
                   <Button
                     variant={"outline"}
-                    onClick={() => form.reset()}
                     disabled={disabled}
+                    onClick={() =>
+                      append({ type: "exam", title: "", date: new Date() })
+                    }
                   >
-                    {dict.dialogs.DateContributeForm.reset}
+                    <Plus className="mr-2" />{" "}
+                    {dict.dialogs.DateContributeForm.add_date}
                   </Button>
-                  <Button
-                    type="submit"
-                    onClick={form.handleSubmit(onSubmit)}
-                    disabled={disabled}
-                  >
-                    {dict.dialogs.DateContributeForm.submit}
-                  </Button>
+                  <div className="flex flex-row gap-2 justify-end">
+                    <Button
+                      variant={"outline"}
+                      onClick={() => form.reset()}
+                      disabled={disabled}
+                    >
+                      {dict.dialogs.DateContributeForm.reset}
+                    </Button>
+                    <Button
+                      type="submit"
+                      onClick={form.handleSubmit(onSubmit)}
+                      disabled={disabled}
+                    >
+                      {dict.dialogs.DateContributeForm.submit}
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            </Form>
-          </ScrollArea>
-        </div>
+              </Form>
+            </ScrollArea>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/CourseDetails/DateContributeForm.tsx
+++ b/apps/web/src/components/CourseDetails/DateContributeForm.tsx
@@ -78,7 +78,9 @@ const DateContributeForm = ({
       const dates = await res.json();
       console.log("fetched dates", dates);
       if (dates == null) throw new Error("Failed to fetch dates");
-      return dates.map((d) => ({
+      return (
+        dates as { id: number; type: string; title: string; date: string }[]
+      ).map((d) => ({
         id: d.id,
         title: d.title,
         type: d.type as "exam" | "quiz" | "no_class",
@@ -149,9 +151,7 @@ const DateContributeForm = ({
             <p className="text-sm text-muted-foreground text-center">
               {dict.dialogs.DateContributeForm.sign_in_required}
             </p>
-            <Button onClick={() => auth.signinRedirect()}>
-              {dict.auth?.sign_in ?? "Sign in"}
-            </Button>
+            <Button onClick={() => auth.signinRedirect()}>Sign in</Button>
           </div>
         ) : (
           <div className="flex flex-col gap-4">

--- a/apps/web/src/components/Timetable/TimetableItemDrawer.tsx
+++ b/apps/web/src/components/Timetable/TimetableItemDrawer.tsx
@@ -7,7 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@courseweb/ui";
 import Compact from "@uiw/react-color-compact";
 import { Drawer, DrawerContent, DrawerTrigger } from "@courseweb/ui";
 import { Button } from "@courseweb/ui";
-import { Book, ExternalLink, CalendarPlus } from "lucide-react";
+import { ExternalLink, CalendarPlus } from "lucide-react";
 import { format } from "date-fns";
 import { Badge } from "@courseweb/ui";
 import DateContributeForm from "@/components/CourseDetails/DateContributeForm";
@@ -147,10 +147,12 @@ const TimetableCourseQuickAccess = ({ course }: { course: MinimalCourse }) => {
             <ExternalLink className="w-4 h-4 mr-2" />
             課程詳情
           </Button>
-          <Button variant="outline" disabled={true}>
-            <Book className="w-4 h-4 mr-2" />
-            學習平臺
-          </Button>
+          <DateContributeForm courseId={course.raw_id}>
+            <Button variant="outline">
+              <CalendarPlus className="w-4 h-4 mr-2" />
+              貢獻日期
+            </Button>
+          </DateContributeForm>
           <Button
             variant="destructive"
             onClick={() => deleteCourse(course.raw_id)}

--- a/apps/web/src/components/Today/TodaySchedule.tsx
+++ b/apps/web/src/components/Today/TodaySchedule.tsx
@@ -20,6 +20,7 @@ import client from "@/config/api";
 import { Badge } from "@courseweb/ui";
 import WeatherIcon from "./WeatherIcon";
 import { cn } from "@courseweb/ui";
+import useCourseDates from "@/hooks/useCourseDates";
 
 const getRangeOfDays = (start: Date, end: Date) => {
   const days = [];
@@ -30,8 +31,14 @@ const getRangeOfDays = (start: Date, end: Date) => {
 };
 
 const TodaySchedule: FC = () => {
-  const { isCoursesEmpty, colorMap, getSemesterCourses } = useUserTimetable();
+  const { isCoursesEmpty, colorMap, getSemesterCourses, courses } =
+    useUserTimetable();
   const { language, pinnedApps, showAcademicCalendar } = useSettings();
+  const enrolledCourseIds = useMemo(
+    () => Object.values(courses).flat(),
+    [courses],
+  );
+  const { getCourseDateForDay } = useCourseDates(enrolledCourseIds);
   const dict = useDictionary();
   const date = useTime();
   const [isClient, setIsClient] = useState(false);
@@ -134,30 +141,59 @@ const TodaySchedule: FC = () => {
 
     return classesThisDay
       .sort((a, b) => a.startTime - b.startTime)
-      .map((t, index) => (
-        <TimetableItemDrawer course={t.course} key={index}>
-          <div className="flex flex-row gap-2 items-start">
-            <div
-              className="size-4 rounded-sm mt-1"
-              style={{ backgroundColor: t.color }}
-            ></div>
-            <div className="flex flex-col gap-1">
-              <div className="font-semibold">
-                {" "}
-                {language == "zh" ? t.course.name_zh : t.course.name_en}{" "}
-              </div>
-              <div className="text-xs text-muted-foreground align-baseline">
-                <Clock className="size-3 inline mr-1" />
-                {`${scheduleTimeSlots[t.startTime]?.start ?? "?"} - ${scheduleTimeSlots[t.endTime]?.end ?? "?"}`}
-              </div>
-              <div className="text-xs text-muted-foreground align-baseline">
-                <MapPin className="size-3 inline mr-1" />
-                {t.venue}
+      .map((t, index) => {
+        const courseDate = getCourseDateForDay(t.course.raw_id, day);
+        const isNoClass = courseDate?.type === "no_class";
+        const isSpecialDate = courseDate && !isNoClass;
+        return (
+          <TimetableItemDrawer course={t.course} key={index}>
+            <div className="flex flex-row gap-2 items-start">
+              <div
+                className="size-4 rounded-sm mt-1 shrink-0"
+                style={
+                  isNoClass
+                    ? {
+                        background:
+                          "repeating-linear-gradient(-45deg, #9ca3af, #9ca3af 4px, #6b7280 4px, #6b7280 8px)",
+                      }
+                    : { backgroundColor: t.color }
+                }
+              />
+              <div className="flex flex-col gap-1">
+                <div
+                  className={cn(
+                    "font-semibold",
+                    isNoClass && "line-through text-muted-foreground",
+                  )}
+                >
+                  {language == "zh" ? t.course.name_zh : t.course.name_en}
+                </div>
+                {isSpecialDate && (
+                  <Badge
+                    variant="secondary"
+                    className="self-start text-[10px] px-1 py-0"
+                  >
+                    {courseDate.type} · {courseDate.title}
+                  </Badge>
+                )}
+                {isNoClass && (
+                  <div className="text-xs text-muted-foreground">
+                    {courseDate.title || dict.today.noclass}
+                  </div>
+                )}
+                <div className="text-xs text-muted-foreground align-baseline">
+                  <Clock className="size-3 inline mr-1" />
+                  {`${scheduleTimeSlots[t.startTime]?.start ?? "?"} - ${scheduleTimeSlots[t.endTime]?.end ?? "?"}`}
+                </div>
+                <div className="text-xs text-muted-foreground align-baseline">
+                  <MapPin className="size-3 inline mr-1" />
+                  {t.venue}
+                </div>
               </div>
             </div>
-          </div>
-        </TimetableItemDrawer>
-      ));
+          </TimetableItemDrawer>
+        );
+      });
   };
 
   const renderCalendars = (day: Date) => {

--- a/apps/web/src/dictionaries/en.json
+++ b/apps/web/src/dictionaries/en.json
@@ -302,7 +302,8 @@
       "add_date": "Add Date",
       "reset": "Reset",
       "submit": "Submit",
-      "accurate_relavent": "Enter only accurate and relavent information!"
+      "accurate_relavent": "Enter only accurate and relavent information!",
+      "sign_in_required": "Sign in to contribute dates for this course"
     }
   },
   "shops": {

--- a/apps/web/src/dictionaries/zh.json
+++ b/apps/web/src/dictionaries/zh.json
@@ -302,7 +302,8 @@
       "add_date": "加日期",
       "reset": "還原",
       "submit": "送出",
-      "accurate_relavent": "請輸入準確並跟此課程有關的日期"
+      "accurate_relavent": "請輸入準確並跟此課程有關的日期",
+      "sign_in_required": "請登入以貢獻課程日期"
     }
   },
   "shops": {

--- a/apps/web/src/hooks/useCourseDates.ts
+++ b/apps/web/src/hooks/useCourseDates.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { isSameDay } from "date-fns";
+import client from "@/config/api";
+
+export type CourseDate = {
+  raw_id: string;
+  id: number;
+  type: string;
+  title: string;
+  date: string;
+};
+
+const useCourseDates = (courseIds: string[]) => {
+  const sortedIds = useMemo(() => [...courseIds].sort(), [courseIds]);
+
+  const { data = [] } = useQuery<CourseDate[]>({
+    queryKey: ["course-dates", ...sortedIds],
+    queryFn: async () => {
+      const res = await client.course.dates.$get({
+        query: { courses: sortedIds },
+      });
+      return res.json();
+    },
+    enabled: sortedIds.length > 0,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const dateMap = useMemo(() => {
+    const map = new Map<string, CourseDate[]>();
+    for (const d of data) {
+      if (!map.has(d.raw_id)) map.set(d.raw_id, []);
+      map.get(d.raw_id)!.push(d);
+    }
+    return map;
+  }, [data]);
+
+  const getCourseDateForDay = useCallback(
+    (rawId: string, day: Date): CourseDate | null => {
+      const dates = dateMap.get(rawId) ?? [];
+      return dates.find((d) => isSameDay(new Date(d.date), day)) ?? null;
+    },
+    [dateMap],
+  );
+
+  return { getCourseDateForDay };
+};
+
+export default useCourseDates;

--- a/apps/web/src/types/api/src/course.d.ts
+++ b/apps/web/src/types/api/src/course.d.ts
@@ -46,6 +46,25 @@ declare const app: import("hono/hono-base").HonoBase<
       };
     };
   } & {
+    "/dates": {
+      $get: {
+        input: {
+          query: {
+            courses: string | string[];
+          };
+        };
+        output: {
+          raw_id: string;
+          id: number;
+          type: string;
+          title: string;
+          date: string;
+        }[];
+        outputFormat: "json";
+        status: import("hono/utils/http-status").ContentfulStatusCode;
+      };
+    };
+  } & {
     "/:courseId": {
       $get: {
         input: {

--- a/apps/web/src/types/secure-api/api/index.d.ts
+++ b/apps/web/src/types/secure-api/api/index.d.ts
@@ -234,6 +234,46 @@ declare const app: import("hono/hono-base").HonoBase<
         };
       },
       "/replication"
+    >
+  | import("hono/types").MergeSchemaPath<
+      {
+        "/:courseId": {
+          $post:
+            | {
+                input: {
+                  param: { courseId: string };
+                  json: {
+                    dates: {
+                      id?: number | undefined;
+                      type: "exam" | "quiz" | "no_class" | "other";
+                      title: string;
+                      date: string;
+                    }[];
+                  };
+                };
+                output: { success: boolean };
+                outputFormat: "json";
+                status: import("hono/utils/http-status").ContentfulStatusCode;
+              }
+            | {
+                input: {
+                  param: { courseId: string };
+                  json: {
+                    dates: {
+                      id?: number | undefined;
+                      type: "exam" | "quiz" | "no_class" | "other";
+                      title: string;
+                      date: string;
+                    }[];
+                  };
+                };
+                output: { error: string };
+                outputFormat: "json";
+                status: 500;
+              };
+        };
+      },
+      "/course-dates"
     >,
   "/"
 >;

--- a/services/api/src/course.ts
+++ b/services/api/src/course.ts
@@ -50,6 +50,36 @@ const app = new Hono()
     },
   )
   .get(
+    "/dates",
+    zValidator(
+      "query",
+      z.object({
+        courses: z.union([z.string(), z.array(z.string())]),
+      }),
+    ),
+    async (c) => {
+      const { courses: _courses } = c.req.valid("query");
+      const courses = Array.isArray(_courses) ? _courses : [_courses];
+      const { data, error } = await supabase_server(c)
+        .from("course_dates")
+        .select("*")
+        .in("raw_id", courses);
+      if (error) {
+        console.error(error);
+        return c.json([]);
+      }
+      return c.json(
+        data.map((d) => ({
+          raw_id: d.raw_id,
+          id: d.id,
+          type: d.type,
+          title: d.title,
+          date: d.date,
+        })),
+      );
+    },
+  )
+  .get(
     "/:courseId",
     zValidator(
       "param",

--- a/services/secure-api/src/api/course-dates.ts
+++ b/services/secure-api/src/api/course-dates.ts
@@ -1,0 +1,82 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+import { requireAuth } from "../middleware/requireAuth";
+import supabase from "../config/supabase";
+
+const app = new Hono().post(
+  "/:courseId",
+  zValidator(
+    "param",
+    z.object({
+      courseId: z.string(),
+    }),
+  ),
+  zValidator(
+    "json",
+    z.object({
+      dates: z.array(
+        z.object({
+          id: z.coerce.number().optional(),
+          type: z.enum(["exam", "quiz", "no_class", "other"]),
+          title: z.string().min(1),
+          date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        }),
+      ),
+    }),
+  ),
+  requireAuth(),
+  async (c) => {
+    const { courseId } = c.req.valid("param");
+    const { dates } = c.req.valid("json");
+    const user = c.get("user");
+
+    const { data: existing, error: fetchError } = await supabase
+      .from("course_dates")
+      .select("id")
+      .eq("raw_id", courseId);
+
+    if (fetchError) {
+      return c.json({ error: "Failed to fetch existing dates" }, 500);
+    }
+
+    const existingIds = new Set((existing ?? []).map((d) => d.id));
+    const submittedIds = new Set(
+      dates.filter((d) => d.id != null).map((d) => d.id!),
+    );
+
+    // Delete rows that were removed by this user's submission
+    const toDelete = [...existingIds].filter((id) => !submittedIds.has(id));
+    if (toDelete.length > 0) {
+      await supabase
+        .from("course_dates")
+        .delete()
+        .in("id", toDelete)
+        .eq("submitter", user.userId);
+    }
+
+    // Upsert new and updated rows
+    const toUpsert = dates.map((d) => ({
+      ...(d.id ? { id: d.id } : {}),
+      raw_id: courseId,
+      type: d.type,
+      title: d.title,
+      date: d.date,
+      submitter: user.userId,
+    }));
+
+    if (toUpsert.length > 0) {
+      const { error: upsertError } = await supabase
+        .from("course_dates")
+        .upsert(toUpsert);
+
+      if (upsertError) {
+        return c.json({ error: "Failed to save dates" }, 500);
+      }
+    }
+
+    return c.json({ success: true });
+  },
+);
+
+export default app;

--- a/services/secure-api/src/api/index.ts
+++ b/services/secure-api/src/api/index.ts
@@ -5,6 +5,7 @@ import kvHandler from "./kv_storage";
 import replicationHandler from "./replication";
 import apiKeysHandler from "./apikeys";
 import calendarHandler from "./calendar";
+import courseDatesHandler from "./course-dates";
 
 const app = new Hono()
   .use(
@@ -18,6 +19,7 @@ const app = new Hono()
   .route("/kv", kvHandler)
   .route("/replication", replicationHandler)
   .route("/apikeys", apiKeysHandler)
-  .route("/calendar", calendarHandler);
+  .route("/calendar", calendarHandler)
+  .route("/course-dates", courseDatesHandler);
 
 export default app;

--- a/services/secure-api/src/config/supabase.ts
+++ b/services/secure-api/src/config/supabase.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@supabase/supabase-js";
 
 const supabase = createClient(
-  process.env.SUPABASE_URL ?? "",
-  process.env.SUPABASE_SERVICE_ROLE_KEY ?? "",
+  process.env["SUPABASE_URL"] ?? "",
+  process.env["SUPABASE_SERVICE_ROLE_KEY"] ?? "",
 );
 
 export default supabase;

--- a/services/secure-api/src/config/supabase.ts
+++ b/services/secure-api/src/config/supabase.ts
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.SUPABASE_URL ?? "",
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? "",
+);
+
+export default supabase;


### PR DESCRIPTION
## Summary

- **Bulk API endpoint**: `GET /course/dates?courseIds=...` on the public Cloudflare Worker API returns all course date entries for enrolled courses in a single request
- **Submit endpoint**: `POST /course-dates/:courseId` on secure-api (Bun) requires auth; validates and upserts dates to Supabase `course_dates` table, deletes removed rows (own only)
- **Calendar integration**: timetable-synced calendar events visually reflect special dates — `no_class` gets gray diagonal stripes, `exam`/`quiz`/`other` get a color badge overlay — in week view, month view, and Today schedule
- **Contribute UI**: `DateContributeForm` accessible from TimetableItemDrawer ("貢獻日期") and EventPopover (CalendarPlus icon on course events). Shows sign-in gate when unauthenticated.

## Test plan

- [ ] Add a `no_class` date for an enrolled course → calendar event shows diagonal gray stripes on that day
- [ ] Add an `exam` date → badge overlay appears on the event chip
- [ ] TimetableItemDrawer → "貢獻日期" button opens the form
- [ ] EventPopover on a course event → CalendarPlus icon opens the form
- [ ] Submit without signing in → sign-in prompt shown
- [ ] Submit while authenticated → dates saved and form resets