### PR TITLE
ci: auto-apply D1 migrations on merge + PR check for schema changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,8 +46,75 @@ jobs:
         run: |
           bun run build
 
+  check-migrations:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check that migration was generated for schema changes
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          SCHEMA_CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- services/api/src/prisma/schema.prisma)
+          if [ -z "$SCHEMA_CHANGED" ]; then
+            echo "schema.prisma unchanged — no migration check needed."
+            exit 0
+          fi
+
+          echo "schema.prisma changed. Verifying migration was generated..."
+
+          PREVIOUS_CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- services/api/src/prisma/schema.previous.prisma)
+          if [ -z "$PREVIOUS_CHANGED" ]; then
+            echo ""
+            echo "ERROR: schema.prisma was changed but schema.previous.prisma was not updated."
+            echo "Please run 'bun run prisma:migration:generate' in services/api and commit the result."
+            exit 1
+          fi
+
+          NEW_MIGRATIONS=$(git diff --name-only "$BASE" "$HEAD" -- 'services/api/migrations/*.sql')
+          if [ -z "$NEW_MIGRATIONS" ]; then
+            echo ""
+            echo "ERROR: schema.prisma was changed but no new migration SQL file was found."
+            echo "Please run 'bun run prisma:migration:generate' in services/api and commit the result."
+            exit 1
+          fi
+
+          echo "Migration check passed. New migration(s):"
+          echo "$NEW_MIGRATIONS"
+
+  migrate-db:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Apply D1 migrations
+        uses: cloudflare/wrangler-action@v3
+        with:
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: services/api
+          command: d1 migrations apply data-d1 --remote
+          packageManager: bun
+
   deploy-api:
     runs-on: ubuntu-latest
+    needs: [migrate-db]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: production
     steps:


### PR DESCRIPTION
## Summary

Adds two new CI jobs to the build workflow to automate Prisma/D1 migration management.

## New jobs

### \`check-migrations\` (runs on PRs)
Fails if \`schema.prisma\` was changed without a corresponding migration being generated. Checks that both \`schema.previous.prisma\` and a new \`.sql\` file under \`migrations/\` are present in the diff. Error message guides the dev to run:
\`\`\`
cd services/api && bun run prisma:migration:generate
\`\`\`

### \`migrate-db\` (runs on merge to main)
Applies any pending migrations to D1 remote via \`wrangler d1 migrations apply data-d1 --remote\` before the Worker is deployed. Safe to run with no new migrations (wrangler tracks applied migrations internally).

### \`deploy-api\` — now depends on \`migrate-db\`
Ensures the schema is always applied before the new Worker code goes live.

## Required secrets
Already present: \`CLOUDFLARE_ACCOUNT_ID\`, \`CLOUDFLARE_API_TOKEN\`

## Developer workflow (unchanged)
1. Edit \`schema.prisma\`
2. Run \`bun run prisma:migration:generate\` in \`services/api\`
3. Commit \`schema.prisma\`, \`schema.previous.prisma\`, and the new SQL file
4. Open PR — the check will validate the migration was generated
5. Merge — CI applies the migration then deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)