### PR TITLE
feat(timetable): integrated share/group/community UX

### DIFF
--- a/apps/web/src/app/[lang]/(mods-pages)/community/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/community/page.tsx
@@ -62,7 +62,7 @@ function TimetableCard({
   return (
     <button
       onClick={onClick}
-      className="flex flex-col gap-2 p-4 rounded-xl border hover:border-primary hover:shadow-md transition-all text-left"
+      className="flex flex-col gap-1.5 p-3 rounded-lg border hover:border-primary hover:shadow-sm transition-all text-left"
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-1">
@@ -235,15 +235,14 @@ const CommunityPage = () => {
   const semesters = [...semesterInfo].reverse().slice(0, 10);
 
   return (
-    <div className="flex flex-col gap-6 px-4 py-6 max-w-5xl mx-auto w-full">
-      <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-4 px-4 py-4 max-w-5xl mx-auto w-full">
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Globe className="h-5 w-5" />
-          <h1 className="text-xl font-semibold">Timetable Community</h1>
+          <Globe className="h-4 w-4" />
+          <h1 className="text-base font-semibold">Community Timetables</h1>
         </div>
-        <p className="text-sm text-muted-foreground">
-          Browse public timetables shared by NTHU students, complete with course
-          notes and grade context.
+        <p className="text-xs text-muted-foreground hidden sm:block">
+          Public timetables from NTHU students
         </p>
       </div>
 
@@ -270,12 +269,12 @@ const CommunityPage = () => {
       </div>
 
       {isLoading ? (
-        <div className="flex justify-center py-16">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       ) : data?.items.length === 0 ? (
-        <div className="flex flex-col items-center py-16 gap-3 text-muted-foreground">
-          <Globe className="h-10 w-10 opacity-30" />
+        <div className="flex flex-col items-center py-8 gap-2 text-muted-foreground">
+          <Globe className="h-8 w-8 opacity-30" />
           <p className="text-sm">No public timetables yet for this filter.</p>
           <p className="text-xs">
             Share yours with "Public gallery" enabled to appear here.
@@ -283,7 +282,7 @@ const CommunityPage = () => {
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {data?.items.map((share) => (
               <TimetableCard
                 key={share.id}

--- a/apps/web/src/app/[lang]/(mods-pages)/community/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/community/page.tsx
@@ -128,8 +128,8 @@ function TimetableDetailDialog({
 }) {
   const navigate = useNavigate();
   const { lang } = useParams<{ lang: string }>();
-  const firstSem = share.semesters[0] ?? "";
-  const courseIds = share.courses[firstSem] ?? [];
+  const [activeSem, setActiveSem] = useState(share.semesters[0] ?? "");
+  const courseIds = share.courses[activeSem] ?? [];
 
   const { data: courses = [] } = useQuery({
     queryKey: ["courses", [...courseIds].sort()],
@@ -141,17 +141,33 @@ function TimetableDetailDialog({
     enabled: courseIds.length > 0,
   });
 
-  const timetableData = createTimetableFromCourses(
-    courses as MinimalCourse[],
-    {},
-  );
+  // Let createTimetableFromCourses generate colors via its default colorMapFromCourses
+  const timetableData = createTimetableFromCourses(courses as MinimalCourse[]);
 
   return (
     <Dialog open onOpenChange={(v) => !v && onClose()}>
       <DialogContent className="max-w-4xl h-[80vh] overflow-auto">
         <DialogHeader>
-          <DialogTitle>
-            {share.displayName || toPrettySemester(firstSem)}
+          <DialogTitle className="flex items-center justify-between gap-4 pr-6">
+            <span>{share.displayName || toPrettySemester(activeSem)}</span>
+            {share.semesters.length > 1 && (
+              <div className="flex gap-1">
+                {share.semesters.map((sem) => (
+                  <button
+                    key={sem}
+                    type="button"
+                    onClick={() => setActiveSem(sem)}
+                    className={`px-2 py-0.5 rounded text-xs font-normal border transition-colors ${
+                      activeSem === sem
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : "border-border text-muted-foreground hover:border-foreground"
+                    }`}
+                  >
+                    {toPrettySemester(sem)}
+                  </button>
+                ))}
+              </div>
+            )}
           </DialogTitle>
         </DialogHeader>
         <div className="grid grid-cols-1 md:grid-cols-[3fr_2fr] gap-4">

--- a/apps/web/src/app/[lang]/(mods-pages)/community/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/community/page.tsx
@@ -215,7 +215,7 @@ function TimetableDetailDialog({
 }
 
 const CommunityPage = () => {
-  const [selectedSemester, setSelectedSemester] = useState<string>("");
+  const [selectedSemester, setSelectedSemester] = useState<string>("all");
   const [offset, setOffset] = useState(0);
   const [selectedShare, setSelectedShare] = useState<SharedTimetable | null>(
     null,
@@ -226,7 +226,7 @@ const CommunityPage = () => {
     queryKey: ["public-timetables", selectedSemester, offset],
     queryFn: () =>
       getPublicGallery({
-        semester: selectedSemester || undefined,
+        semester: selectedSemester === "all" ? undefined : selectedSemester,
         limit: 24,
         offset,
       }),
@@ -259,7 +259,7 @@ const CommunityPage = () => {
             <SelectValue placeholder="All semesters" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">All semesters</SelectItem>
+            <SelectItem value="all">All semesters</SelectItem>
             {semesters.map((s) => (
               <SelectItem key={s.id} value={s.id}>
                 {toPrettySemester(s.id)}

--- a/apps/web/src/app/[lang]/(mods-pages)/group/[code]/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/group/[code]/page.tsx
@@ -6,6 +6,7 @@ import {
   type TimetableGroup,
 } from "@/hooks/useTimetableShare";
 import { useAuth } from "react-oidc-context";
+import useUserTimetable from "@/hooks/contexts/useUserTimetable";
 import client from "@/config/api";
 import { MinimalCourse } from "@/types/courses";
 import { createTimetableFromCourses } from "@/helpers/timetable";
@@ -13,6 +14,7 @@ import { CourseTimeslotData } from "@/types/timetable";
 import Timetable from "@/components/Timetable/Timetable";
 import { toPrettySemester } from "@/helpers/semester";
 import { Button } from "@courseweb/ui";
+import { Input } from "@courseweb/ui";
 import { toast } from "@courseweb/ui";
 import { Separator } from "@courseweb/ui";
 import { Copy, Check, Loader2, Users, LogOut, Eye, EyeOff } from "lucide-react";
@@ -52,13 +54,14 @@ const GroupViewPage = () => {
   const { code } = useParams<{ code: string; lang: string }>();
   const { lang } = useParams<{ lang: string }>();
   const navigate = useNavigate();
-  const { isAuthenticated } = useAuth();
-  const { getGroup, joinGroup, leaveGroup, listOwnShares } =
+  const { isAuthenticated, user: authUser } = useAuth();
+  const { courses: userCourses } = useUserTimetable();
+  const { getGroup, joinGroup, leaveGroup, listOwnShares, createShare } =
     useTimetableShare();
   const queryClient = useQueryClient();
   const [visibleMembers, setVisibleMembers] = useState<Set<string>>(new Set());
   const [copied, setCopied] = useState(false);
-  const [selectedShareId, setSelectedShareId] = useState("");
+  const [displayName, setDisplayName] = useState("");
 
   const { data: group, isLoading } = useQuery({
     queryKey: ["group", code],
@@ -75,9 +78,33 @@ const GroupViewPage = () => {
   });
 
   const joinMutation = useMutation({
-    mutationFn: () => joinGroup(code!, { sharedTimetableId: selectedShareId }),
+    mutationFn: async () => {
+      const name = displayName.trim();
+      if (!name) throw new Error("Please enter your name");
+
+      const sem = group?.semester;
+      if (!sem) throw new Error("Group not loaded");
+
+      // Reuse existing share for this semester, or auto-create one
+      const existingShare = ownShares.find((s) => s.semesters.includes(sem));
+      let shareId = existingShare?.id;
+
+      if (!shareId) {
+        const created = await createShare({
+          displayName: name,
+          semesters: [sem],
+          courses: { [sem]: userCourses[sem] ?? [] },
+          isLive: true,
+          visibility: "link_only",
+        });
+        shareId = created.id;
+      }
+
+      return joinGroup(code!, { sharedTimetableId: shareId, label: name });
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["group", code] });
+      queryClient.invalidateQueries({ queryKey: ["own-shares"] });
       toast({ title: "Joined group!" });
     },
     onError: (e: Error) =>
@@ -102,8 +129,12 @@ const GroupViewPage = () => {
     });
   };
 
+  const currentUserId = authUser?.profile?.sub;
+  const isAlreadyMember =
+    !!group && group.members.some((m) => m.userId === currentUserId);
+
   const copyInviteUrl = () => {
-    const url = `${window.location.origin}/${lang}/group/${code}`;
+    const url = `${window.location.origin}/${lang}/timetable/group/${code}`;
     navigator.clipboard.writeText(url).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
@@ -178,7 +209,7 @@ const GroupViewPage = () => {
             )}
             Copy invite link
           </Button>
-          {isAuthenticated && (
+          {isAuthenticated && isAlreadyMember && (
             <Button
               variant="ghost"
               size="sm"
@@ -248,32 +279,25 @@ const GroupViewPage = () => {
             })}
           </div>
 
-          {isAuthenticated && (
+          {isAuthenticated && !isAlreadyMember && (
             <>
               <Separator />
               <div className="flex flex-col gap-2">
                 <h3 className="text-sm font-medium">Join this group</h3>
                 <p className="text-xs text-muted-foreground">
-                  Select one of your share links to show your timetable to the
-                  group.
+                  Enter your name so members can identify you. We'll link your
+                  timetable automatically.
                 </p>
-                <select
-                  className="text-sm border rounded-md p-2 bg-background"
-                  value={selectedShareId}
-                  onChange={(e) => setSelectedShareId(e.target.value)}
-                >
-                  <option value="">Select a share link...</option>
-                  {ownShares
-                    .filter((s) => s.semesters.includes(semester))
-                    .map((s) => (
-                      <option key={s.id} value={s.id}>
-                        {s.displayName || toPrettySemester(s.semesters[0])}
-                      </option>
-                    ))}
-                </select>
+                <Input
+                  placeholder="Your name or nickname"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  maxLength={60}
+                  className="text-sm"
+                />
                 <Button
                   onClick={() => joinMutation.mutate()}
-                  disabled={!selectedShareId || joinMutation.isPending}
+                  disabled={!displayName.trim() || joinMutation.isPending}
                   size="sm"
                 >
                   {joinMutation.isPending ? (
@@ -281,18 +305,6 @@ const GroupViewPage = () => {
                   ) : null}
                   Join Group
                 </Button>
-                {ownShares.filter((s) => s.semesters.includes(semester))
-                  .length === 0 && (
-                  <p className="text-xs text-muted-foreground">
-                    No share links for {toPrettySemester(semester)} yet.{" "}
-                    <button
-                      className="underline"
-                      onClick={() => navigate(`/${lang}/timetable`)}
-                    >
-                      Create one in Timetable
-                    </button>
-                  </p>
-                )}
               </div>
             </>
           )}

--- a/apps/web/src/app/[lang]/(mods-pages)/group/[code]/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/group/[code]/page.tsx
@@ -17,7 +17,16 @@ import { Button } from "@courseweb/ui";
 import { Input } from "@courseweb/ui";
 import { toast } from "@courseweb/ui";
 import { Separator } from "@courseweb/ui";
-import { Copy, Check, Loader2, Users, LogOut, Eye, EyeOff } from "lucide-react";
+import {
+  Copy,
+  Check,
+  Loader2,
+  Users,
+  LogOut,
+  Eye,
+  EyeOff,
+  Trash2,
+} from "lucide-react";
 
 const MEMBER_COLORS = [
   "#3b82f6",
@@ -56,8 +65,14 @@ const GroupViewPage = () => {
   const navigate = useNavigate();
   const { isAuthenticated, user: authUser } = useAuth();
   const { courses: userCourses } = useUserTimetable();
-  const { getGroup, joinGroup, leaveGroup, listOwnShares, createShare } =
-    useTimetableShare();
+  const {
+    getGroup,
+    joinGroup,
+    leaveGroup,
+    deleteGroup,
+    listOwnShares,
+    createShare,
+  } = useTimetableShare();
   const queryClient = useQueryClient();
   const [visibleMembers, setVisibleMembers] = useState<Set<string>>(new Set());
   const [copied, setCopied] = useState(false);
@@ -105,6 +120,7 @@ const GroupViewPage = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["group", code] });
       queryClient.invalidateQueries({ queryKey: ["own-shares"] });
+      queryClient.invalidateQueries({ queryKey: ["my-groups"] });
       toast({ title: "Joined group!" });
     },
     onError: (e: Error) =>
@@ -115,9 +131,21 @@ const GroupViewPage = () => {
     mutationFn: () => leaveGroup(code!),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["group", code] });
+      queryClient.invalidateQueries({ queryKey: ["my-groups"] });
       navigate(-1);
       toast({ title: "Left group" });
     },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteGroup(code!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["my-groups"] });
+      navigate(-1);
+      toast({ title: "Group deleted" });
+    },
+    onError: (e: Error) =>
+      toast({ title: "Error", description: e.message, variant: "destructive" }),
   });
 
   const toggleMember = (userId: string) => {
@@ -219,6 +247,24 @@ const GroupViewPage = () => {
               <LogOut className="h-4 w-4 mr-1" /> Leave
             </Button>
           )}
+          {isAuthenticated &&
+            currentUserId &&
+            group.createdBy === currentUserId && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => {
+                  if (
+                    window.confirm("Delete this group? This cannot be undone.")
+                  ) {
+                    deleteMutation.mutate();
+                  }
+                }}
+                disabled={deleteMutation.isPending}
+              >
+                <Trash2 className="h-4 w-4 mr-1" /> Delete group
+              </Button>
+            )}
         </div>
       </div>
 

--- a/apps/web/src/components/Calendar/CalendarPage.tsx
+++ b/apps/web/src/components/Calendar/CalendarPage.tsx
@@ -7,6 +7,15 @@ import OthersTimetablePanel, {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@courseweb/ui";
 import { useSavedTimetables } from "@/hooks/useSavedTimetables";
 import { Badge } from "@courseweb/ui";
+import { Button } from "@courseweb/ui";
+import { Users } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@courseweb/ui";
 
 const CalendarPage = () => {
   const [activeOverlays, setActiveOverlays] = useState<OverlayEntry[]>([]);
@@ -44,6 +53,32 @@ const CalendarPage = () => {
               />
             </TabsContent>
           </Tabs>
+        </div>
+        <div className="fixed bottom-4 right-4 xl:hidden z-10">
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button size="sm" variant="outline" className="shadow-md gap-1.5">
+                <Users className="h-4 w-4" />
+                Others
+                {totalUnread > 0 && (
+                  <Badge variant="destructive" className="h-4 text-xs px-1">
+                    {totalUnread}
+                  </Badge>
+                )}
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-80 p-0 flex flex-col">
+              <SheetHeader className="p-4 pb-0">
+                <SheetTitle>Others&apos; Timetables</SheetTitle>
+              </SheetHeader>
+              <div className="flex-1 overflow-auto p-4 pt-2">
+                <OthersTimetablePanel
+                  activeOverlays={activeOverlays}
+                  onOverlayChange={setActiveOverlays}
+                />
+              </div>
+            </SheetContent>
+          </Sheet>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/Calendar/OthersTimetablePanel.tsx
+++ b/apps/web/src/components/Calendar/OthersTimetablePanel.tsx
@@ -246,7 +246,7 @@ const OthersTimetablePanel = ({
           size="sm"
           variant="outline"
           className="h-7 text-xs"
-          onClick={() => navigate(`/${lang}/community`)}
+          onClick={() => navigate(`/${lang}/timetable/community`)}
         >
           Browse
         </Button>

--- a/apps/web/src/components/Timetable/DownloadTimetableDialog.tsx
+++ b/apps/web/src/components/Timetable/DownloadTimetableDialog.tsx
@@ -3,7 +3,7 @@ import { Download, Image, Loader2 } from "lucide-react";
 import Timetable from "./Timetable";
 import useUserTimetable from "@/hooks/contexts/useUserTimetable";
 import { toPng } from "html-to-image";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, type ReactNode } from "react";
 import { createTimetableFromCourses } from "@/helpers/timetable";
 import { MinimalCourse } from "@/types/courses";
 import {
@@ -205,7 +205,13 @@ const DownloadTimetableComponent = () => {
   );
 };
 
-const DownloadTimetableDialog = ({ icsfileLink }: { icsfileLink: string }) => {
+const DownloadTimetableDialog = ({
+  icsfileLink,
+  children,
+}: {
+  icsfileLink: string;
+  children?: ReactNode;
+}) => {
   const dict = useDictionary();
 
   const handleDownloadCalendar = async () => {
@@ -234,10 +240,12 @@ const DownloadTimetableDialog = ({ icsfileLink }: { icsfileLink: string }) => {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline">
-          <Download className="w-4 h-4 mr-1" />{" "}
-          {dict.timetable.actions.download}
-        </Button>
+        {children ?? (
+          <Button variant="outline">
+            <Download className="w-4 h-4 mr-1" />{" "}
+            {dict.timetable.actions.download}
+          </Button>
+        )}
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
+++ b/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
@@ -7,6 +7,7 @@ import {
   Link,
   Loader2,
   Lock,
+  Plus,
   RefreshCw,
   Share2,
   Trash2,
@@ -46,6 +47,28 @@ import { useAuth } from "react-oidc-context";
 import { toPrettySemester } from "@/helpers/semester";
 import client from "@/config/api";
 import { CourseDefinition } from "@/config/supabase";
+import { useNavigate, useParams } from "react-router-dom";
+
+const LS_GROUPS_KEY = "timetable_groups";
+
+type StoredGroup = {
+  code: string;
+  name: string;
+  semester: string;
+};
+
+function readStoredGroups(): StoredGroup[] {
+  try {
+    return JSON.parse(localStorage.getItem(LS_GROUPS_KEY) ?? "[]");
+  } catch {
+    return [];
+  }
+}
+
+function saveStoredGroup(group: StoredGroup) {
+  const existing = readStoredGroups().filter((g) => g.code !== group.code);
+  localStorage.setItem(LS_GROUPS_KEY, JSON.stringify([group, ...existing]));
+}
 
 type Visibility = "link_only" | "public";
 
@@ -155,9 +178,218 @@ function NoteEditor({
   );
 }
 
+function GroupsTab({
+  semester,
+  ownShares,
+  sharesLoading,
+}: {
+  semester: string;
+  ownShares: SharedTimetable[];
+  sharesLoading: boolean;
+}) {
+  const [groupName, setGroupName] = useState("");
+  const [selectedShareId, setSelectedShareId] = useState("");
+  const [createdInviteUrl, setCreatedInviteUrl] = useState<string | null>(null);
+  const [copiedCreate, setCopiedCreate] = useState(false);
+  const [copiedGroup, setCopiedGroup] = useState<string | null>(null);
+  const [storedGroups, setStoredGroups] =
+    useState<StoredGroup[]>(readStoredGroups);
+  const { createGroup } = useTimetableShare();
+  const navigate = useNavigate();
+  const { lang } = useParams<{ lang: string }>();
+
+  const semesterShares = ownShares.filter((s) =>
+    s.semesters.includes(semester),
+  );
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createGroup({
+        name: groupName,
+        semester,
+        sharedTimetableId: selectedShareId || undefined,
+      }),
+    onSuccess: (group) => {
+      const inviteUrl = `${window.location.origin}/${lang}/group/${group.inviteCode}`;
+      setCreatedInviteUrl(inviteUrl);
+      const stored: StoredGroup = {
+        code: group.inviteCode,
+        name: group.name,
+        semester: group.semester,
+      };
+      saveStoredGroup(stored);
+      setStoredGroups(readStoredGroups());
+      setGroupName("");
+      setSelectedShareId("");
+      toast({ title: "Group created!", description: group.name });
+    },
+    onError: (e: Error) =>
+      toast({ title: "Error", description: e.message, variant: "destructive" }),
+  });
+
+  const copyInviteUrl = (url: string, key: string) => {
+    navigator.clipboard.writeText(url).then(() => {
+      setCopiedGroup(key);
+      setTimeout(() => setCopiedGroup(null), 2000);
+    });
+  };
+
+  const copyCreatedUrl = () => {
+    if (!createdInviteUrl) return;
+    navigator.clipboard.writeText(createdInviteUrl).then(() => {
+      setCopiedCreate(true);
+      setTimeout(() => setCopiedCreate(false), 2000);
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-6 mt-4">
+      <div className="flex flex-col gap-4">
+        <h3 className="text-sm font-semibold">Create a Group</h3>
+        <p className="text-xs text-muted-foreground -mt-2">
+          You need a share link to join. Create one in the "Create Link" tab
+          first.
+        </p>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="group-name">Group name</Label>
+          <Input
+            id="group-name"
+            placeholder="e.g. CS Friends 113-2"
+            value={groupName}
+            onChange={(e) => setGroupName(e.target.value)}
+            maxLength={100}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label>Semester</Label>
+          <p className="text-sm text-muted-foreground">
+            {toPrettySemester(semester)}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="group-share">Attach your share link (optional)</Label>
+          {sharesLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading shares...
+            </div>
+          ) : (
+            <select
+              id="group-share"
+              className="text-sm border rounded-md p-2 bg-background"
+              value={selectedShareId}
+              onChange={(e) => setSelectedShareId(e.target.value)}
+            >
+              <option value="">None</option>
+              {semesterShares.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.displayName || toPrettySemester(s.semesters[0] ?? "")}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <Button
+          onClick={() => createMutation.mutate()}
+          disabled={createMutation.isPending || !groupName.trim()}
+          className="w-full"
+        >
+          {createMutation.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Creating...
+            </>
+          ) : (
+            <>
+              <Plus className="h-4 w-4 mr-2" /> Create Group
+            </>
+          )}
+        </Button>
+
+        {createdInviteUrl && (
+          <div className="flex flex-col gap-2 p-3 rounded-lg border bg-muted/30">
+            <p className="text-xs font-medium">
+              Invite link — share this with friends
+            </p>
+            <div className="flex gap-2">
+              <Input
+                value={createdInviteUrl}
+                readOnly
+                className="flex-1 font-mono text-xs"
+              />
+              <Button size="icon" variant="outline" onClick={copyCreatedUrl}>
+                {copiedCreate ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Separator />
+
+      <div className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold">My Groups</h3>
+        {storedGroups.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No groups yet. Create one above.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {storedGroups.map((g) => {
+              const inviteUrl = `${window.location.origin}/${lang}/group/${g.code}`;
+              const isCopied = copiedGroup === g.code;
+              return (
+                <div
+                  key={g.code}
+                  className="flex items-center gap-2 p-2 rounded-lg border"
+                >
+                  <div className="flex flex-col flex-1 min-w-0">
+                    <span className="text-sm font-medium truncate">
+                      {g.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {toPrettySemester(g.semester)}
+                    </span>
+                  </div>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 shrink-0"
+                    onClick={() => copyInviteUrl(inviteUrl, g.code)}
+                  >
+                    {isCopied ? (
+                      <Check className="h-3.5 w-3.5" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 shrink-0"
+                    onClick={() => navigate(`/${lang}/group/${g.code}`)}
+                  >
+                    Open
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
   const [open, setOpen] = useState(false);
-  const [tab, setTab] = useState<"create" | "manage">("create");
+  const [tab, setTab] = useState<"create" | "manage" | "groups">("create");
   const [visibility, setVisibility] = useState<Visibility>("link_only");
   const [isLive, setIsLive] = useState(true);
   const [isAnonymous, setIsAnonymous] = useState(false);
@@ -260,7 +492,7 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
 
         <Tabs
           value={tab}
-          onValueChange={(v) => setTab(v as "create" | "manage")}
+          onValueChange={(v) => setTab(v as "create" | "manage" | "groups")}
         >
           <TabsList className="w-full">
             <TabsTrigger value="create" className="flex-1">
@@ -273,6 +505,10 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
                   {ownShares.length}
                 </Badge>
               )}
+            </TabsTrigger>
+            <TabsTrigger value="groups" className="flex-1">
+              <Users className="h-3.5 w-3.5 mr-1" />
+              Groups
             </TabsTrigger>
           </TabsList>
 
@@ -503,6 +739,14 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
                 ))}
               </div>
             )}
+          </TabsContent>
+
+          <TabsContent value="groups">
+            <GroupsTab
+              semester={semester}
+              ownShares={ownShares}
+              sharesLoading={sharesLoading}
+            />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
+++ b/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
@@ -409,31 +409,48 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
   const { createShare, deleteShare, listOwnShares } = useTimetableShare();
   const queryClient = useQueryClient();
 
+  // Multi-semester selection — default to active semester
+  const [selectedSemesters, setSelectedSemesters] = useState<string[]>([
+    semester,
+  ]);
+  const allSemestersWithCourses = Object.keys(courses).filter(
+    (s) => (courses[s] ?? []).length > 0,
+  );
+  const toggleSemester = (sem: string) => {
+    setSelectedSemesters((prev) =>
+      prev.includes(sem) ? prev.filter((s) => s !== sem) : [...prev, sem],
+    );
+  };
+  const allSelectedCourseIds = selectedSemesters.flatMap(
+    (s) => courses[s] ?? [],
+  );
+
   const { data: ownShares = [], isLoading: sharesLoading } = useQuery({
     queryKey: ["own-shares"],
     queryFn: listOwnShares,
     enabled: open && isAuthenticated,
   });
 
-  const semesterCourseIds = courses[semester] ?? [];
   const { data: semesterCourses = [] } = useQuery({
-    queryKey: ["courses", [...semesterCourseIds].sort()],
+    queryKey: ["courses", [...allSelectedCourseIds].sort()],
     queryFn: async () => {
-      if (!semesterCourseIds.length) return [];
+      if (!allSelectedCourseIds.length) return [];
       const res = await client.course.$get({
-        query: { courses: semesterCourseIds },
+        query: { courses: allSelectedCourseIds },
       });
       return res.json() as Promise<CourseDefinition[]>;
     },
-    enabled: open && semesterCourseIds.length > 0,
+    enabled: open && allSelectedCourseIds.length > 0,
   });
 
   const createMutation = useMutation({
     mutationFn: () =>
       createShare({
         displayName: displayName || undefined,
-        semesters: [semester],
-        courses: { [semester]: semesterCourseIds },
+        semesters: selectedSemesters,
+        courses: Object.fromEntries(
+          selectedSemesters.map((s) => [s, courses[s] ?? []]),
+        ),
         courseNotes,
         visibility,
         isLive,
@@ -488,7 +505,11 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
             <Share2 className="h-5 w-5" /> Share Timetable
           </DialogTitle>
           <DialogDescription>
-            {toPrettySemester(semester)} · {semesterCourseIds.length} courses
+            {selectedSemesters.length === 0
+              ? "No semesters selected"
+              : selectedSemesters.length === 1
+                ? `${toPrettySemester(selectedSemesters[0])} · ${allSelectedCourseIds.length} courses`
+                : `${selectedSemesters.length} semesters · ${allSelectedCourseIds.length} courses`}
           </DialogDescription>
         </DialogHeader>
 
@@ -525,6 +546,28 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
                 maxLength={100}
               />
             </div>
+
+            {allSemestersWithCourses.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <Label>Semesters</Label>
+                <div className="flex flex-wrap gap-2">
+                  {allSemestersWithCourses.map((sem) => (
+                    <button
+                      key={sem}
+                      type="button"
+                      onClick={() => toggleSemester(sem)}
+                      className={`px-3 py-1 rounded-full text-xs border transition-colors ${
+                        selectedSemesters.includes(sem)
+                          ? "bg-primary text-primary-foreground border-primary"
+                          : "bg-background border-border text-muted-foreground hover:border-foreground"
+                      }`}
+                    >
+                      {toPrettySemester(sem)} · {(courses[sem] ?? []).length}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
 
             <div className="flex flex-col gap-3">
               <div className="flex items-center justify-between">
@@ -680,7 +723,9 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
             <Button
               onClick={() => createMutation.mutate()}
               disabled={
-                createMutation.isPending || semesterCourseIds.length === 0
+                createMutation.isPending ||
+                selectedSemesters.length === 0 ||
+                allSelectedCourseIds.length === 0
               }
               className="w-full"
             >
@@ -695,11 +740,17 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
                 </>
               )}
             </Button>
-            {semesterCourseIds.length === 0 && (
+            {selectedSemesters.length === 0 && (
               <p className="text-xs text-center text-muted-foreground">
-                Add courses first
+                Select at least one semester
               </p>
             )}
+            {selectedSemesters.length > 0 &&
+              allSelectedCourseIds.length === 0 && (
+                <p className="text-xs text-center text-muted-foreground">
+                  Add courses first
+                </p>
+              )}
           </TabsContent>
 
           <TabsContent value="manage" className="mt-4">

--- a/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
+++ b/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
@@ -210,7 +210,7 @@ function GroupsTab({
         sharedTimetableId: selectedShareId || undefined,
       }),
     onSuccess: (group) => {
-      const inviteUrl = `${window.location.origin}/${lang}/group/${group.inviteCode}`;
+      const inviteUrl = `${window.location.origin}/${lang}/timetable/group/${group.inviteCode}`;
       setCreatedInviteUrl(inviteUrl);
       const stored: StoredGroup = {
         code: group.inviteCode,
@@ -342,7 +342,7 @@ function GroupsTab({
         ) : (
           <div className="flex flex-col gap-3">
             {storedGroups.map((g) => {
-              const inviteUrl = `${window.location.origin}/${lang}/group/${g.code}`;
+              const inviteUrl = `${window.location.origin}/${lang}/timetable/group/${g.code}`;
               const isCopied = copiedGroup === g.code;
               return (
                 <div
@@ -373,7 +373,9 @@ function GroupsTab({
                     size="sm"
                     variant="outline"
                     className="h-7 shrink-0"
-                    onClick={() => navigate(`/${lang}/group/${g.code}`)}
+                    onClick={() =>
+                      navigate(`/${lang}/timetable/group/${g.code}`)
+                    }
                   >
                     Open
                   </Button>

--- a/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
+++ b/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
   Lock,
   Plus,
+  QrCode,
   RefreshCw,
   Share2,
   Trash2,
@@ -31,13 +32,20 @@ import { Input } from "@courseweb/ui";
 import { Label } from "@courseweb/ui";
 import { Switch } from "@courseweb/ui";
 import { Badge } from "@courseweb/ui";
-import { Textarea } from "@courseweb/ui";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@courseweb/ui";
 import { Separator } from "@courseweb/ui";
+import { ScrollArea } from "@courseweb/ui";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@courseweb/ui";
 import useUserTimetable from "@/hooks/contexts/useUserTimetable";
 import {
   useTimetableShare,
@@ -45,42 +53,31 @@ import {
 } from "@/hooks/useTimetableShare";
 import { useAuth } from "react-oidc-context";
 import { toPrettySemester } from "@/helpers/semester";
+import { semesterInfo } from "@courseweb/shared";
 import client from "@/config/api";
 import { CourseDefinition } from "@/config/supabase";
 import { useNavigate, useParams } from "react-router-dom";
 
-const LS_GROUPS_KEY = "timetable_groups";
-
-type StoredGroup = {
-  code: string;
-  name: string;
-  semester: string;
-};
-
-function readStoredGroups(): StoredGroup[] {
-  try {
-    return JSON.parse(localStorage.getItem(LS_GROUPS_KEY) ?? "[]");
-  } catch {
-    return [];
-  }
-}
-
-function saveStoredGroup(group: StoredGroup) {
-  const existing = readStoredGroups().filter((g) => g.code !== group.code);
-  localStorage.setItem(LS_GROUPS_KEY, JSON.stringify([group, ...existing]));
+function useLang() {
+  const { lang } = useParams<{ lang: string }>();
+  return lang ?? "en";
 }
 
 type Visibility = "link_only" | "public";
 
-function ShareLinkPanel({
+// ── Compact share list item with collapsible QR ──────────────────────────────
+function ShareListItem({
   share,
   onDelete,
 }: {
-  share: SharedTimetable & { shareUrl: string };
+  share: SharedTimetable;
   onDelete: () => void;
 }) {
+  const [expanded, setExpanded] = useState(false);
+  const [showQr, setShowQr] = useState(false);
   const [copied, setCopied] = useState(false);
-  const url = `${window.location.origin}/${window.location.pathname.split("/")[1]}/timetable/share/${share.id}`;
+  const lang = useLang();
+  const url = `${window.location.origin}/${lang}/timetable/share/${share.id}`;
 
   const copy = () => {
     navigator.clipboard.writeText(url).then(() => {
@@ -90,58 +87,87 @@ function ShareLinkPanel({
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-2">
-        <Input value={url} readOnly className="flex-1 font-mono text-sm" />
-        <Button size="icon" variant="outline" onClick={copy}>
+    <div className="rounded-lg border overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <div className="flex flex-col flex-1 min-w-0">
+          <span className="text-sm font-medium truncate">
+            {share.displayName || toPrettySemester(share.semesters[0] ?? "")}
+          </span>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {share.isLive ? (
+              <span className="flex items-center gap-0.5">
+                <RefreshCw className="h-2.5 w-2.5" /> Live
+              </span>
+            ) : (
+              <span className="flex items-center gap-0.5">
+                <Lock className="h-2.5 w-2.5" /> Snapshot
+              </span>
+            )}
+            {share.visibility === "public" && (
+              <span className="flex items-center gap-0.5">
+                <Globe className="h-2.5 w-2.5" /> Public
+              </span>
+            )}
+          </div>
+        </div>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 shrink-0"
+          onClick={copy}
+        >
           {copied ? (
-            <Check className="h-4 w-4" />
+            <Check className="h-3.5 w-3.5" />
           ) : (
-            <Copy className="h-4 w-4" />
+            <Copy className="h-3.5 w-3.5" />
           )}
         </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 shrink-0"
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <ChevronDown
+            className={`h-3.5 w-3.5 transition-transform duration-150 ${expanded ? "rotate-180" : ""}`}
+          />
+        </Button>
       </div>
-      <div className="flex gap-2 items-start">
-        <div className="p-2 bg-white rounded border">
-          <QRCodeSVG value={url} size={120} />
-        </div>
-        <div className="flex flex-col gap-2 flex-1">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            {share.isLive ? (
-              <>
-                <RefreshCw className="h-3 w-3" /> Live sync
-              </>
-            ) : (
-              <>
-                <Lock className="h-3 w-3" /> Snapshot
-              </>
-            )}
+
+      {expanded && (
+        <div className="border-t px-3 py-3 flex flex-col gap-3 bg-muted/20">
+          <Input value={url} readOnly className="font-mono text-xs h-7" />
+          <div className="flex items-center justify-between">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs px-2"
+              onClick={() => setShowQr((v) => !v)}
+            >
+              <QrCode className="h-3 w-3 mr-1" />
+              {showQr ? "Hide QR" : "Show QR"}
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              className="h-7 text-xs px-2"
+              onClick={onDelete}
+            >
+              <Trash2 className="h-3 w-3 mr-1" /> Delete
+            </Button>
           </div>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            {share.visibility === "public" ? (
-              <>
-                <Globe className="h-3 w-3" /> Public gallery
-              </>
-            ) : (
-              <>
-                <Link className="h-3 w-3" /> Link only
-              </>
-            )}
-          </div>
-          <Button
-            size="sm"
-            variant="destructive"
-            className="mt-auto"
-            onClick={onDelete}
-          >
-            <Trash2 className="h-3 w-3 mr-1" /> Delete link
-          </Button>
+          {showQr && (
+            <div className="flex justify-center p-3 bg-white rounded border">
+              <QRCodeSVG value={url} size={96} />
+            </div>
+          )}
         </div>
-      </div>
+      )}
     </div>
   );
 }
 
+// ── Course note editor ────────────────────────────────────────────────────────
 function NoteEditor({
   courseId,
   courseNote,
@@ -178,220 +204,181 @@ function NoteEditor({
   );
 }
 
-function GroupsTab({
-  semester,
-  ownShares,
-  sharesLoading,
-}: {
-  semester: string;
-  ownShares: SharedTimetable[];
-  sharesLoading: boolean;
-}) {
+// ── Groups tab — create a group with semester picker + nickname ───────────────
+function GroupsTab({ semester: activeSemester }: { semester: string }) {
   const [groupName, setGroupName] = useState("");
-  const [selectedShareId, setSelectedShareId] = useState("");
-  const [createdInviteUrl, setCreatedInviteUrl] = useState<string | null>(null);
-  const [copiedCreate, setCopiedCreate] = useState(false);
-  const [copiedGroup, setCopiedGroup] = useState<string | null>(null);
-  const [storedGroups, setStoredGroups] =
-    useState<StoredGroup[]>(readStoredGroups);
-  const { createGroup } = useTimetableShare();
+  const [groupSemester, setGroupSemester] = useState(activeSemester);
+  const [creatorLabel, setCreatorLabel] = useState("");
+  const [created, setCreated] = useState<{
+    inviteCode: string;
+    name: string;
+  } | null>(null);
+  const [copiedInvite, setCopiedInvite] = useState(false);
+
+  const { courses } = useUserTimetable();
+  const { createShare, createGroup } = useTimetableShare();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { lang } = useParams<{ lang: string }>();
 
-  const semesterShares = ownShares.filter((s) =>
-    s.semesters.includes(semester),
-  );
+  const recentSemesters = [...semesterInfo].reverse().slice(0, 10);
 
   const createMutation = useMutation({
-    mutationFn: () =>
-      createGroup({
-        name: groupName,
-        semester,
-        sharedTimetableId: selectedShareId || undefined,
-      }),
+    mutationFn: async () => {
+      // Auto-create a live share for the chosen semester
+      const share = await createShare({
+        displayName: groupName.trim(),
+        semesters: [groupSemester],
+        courses: { [groupSemester]: courses[groupSemester] ?? [] },
+        isLive: true,
+        visibility: "link_only",
+      });
+      return createGroup({
+        name: groupName.trim(),
+        semester: groupSemester,
+        sharedTimetableId: share.id,
+        creatorLabel: creatorLabel.trim() || undefined,
+      });
+    },
     onSuccess: (group) => {
-      const inviteUrl = `${window.location.origin}/${lang}/timetable/group/${group.inviteCode}`;
-      setCreatedInviteUrl(inviteUrl);
-      const stored: StoredGroup = {
-        code: group.inviteCode,
-        name: group.name,
-        semester: group.semester,
-      };
-      saveStoredGroup(stored);
-      setStoredGroups(readStoredGroups());
-      setGroupName("");
-      setSelectedShareId("");
-      toast({ title: "Group created!", description: group.name });
+      queryClient.invalidateQueries({ queryKey: ["my-groups"] });
+      queryClient.invalidateQueries({ queryKey: ["own-shares"] });
+      setCreated({ inviteCode: group.inviteCode, name: group.name });
     },
     onError: (e: Error) =>
       toast({ title: "Error", description: e.message, variant: "destructive" }),
   });
 
-  const copyInviteUrl = (url: string, key: string) => {
-    navigator.clipboard.writeText(url).then(() => {
-      setCopiedGroup(key);
-      setTimeout(() => setCopiedGroup(null), 2000);
+  const inviteUrl = created
+    ? `${window.location.origin}/${lang}/timetable/group/${created.inviteCode}`
+    : null;
+
+  const copyInvite = () => {
+    if (!inviteUrl) return;
+    navigator.clipboard.writeText(inviteUrl).then(() => {
+      setCopiedInvite(true);
+      setTimeout(() => setCopiedInvite(false), 2000);
     });
   };
 
-  const copyCreatedUrl = () => {
-    if (!createdInviteUrl) return;
-    navigator.clipboard.writeText(createdInviteUrl).then(() => {
-      setCopiedCreate(true);
-      setTimeout(() => setCopiedCreate(false), 2000);
-    });
-  };
+  if (created && inviteUrl) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="text-center py-2">
+          <p className="font-semibold">{created.name}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Group created — share the link below
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Input
+            value={inviteUrl}
+            readOnly
+            className="font-mono text-xs flex-1"
+          />
+          <Button size="icon" variant="outline" onClick={copyInvite}>
+            {copiedInvite ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+        <Button
+          className="w-full"
+          onClick={() =>
+            navigate(`/${lang}/timetable/group/${created.inviteCode}`)
+          }
+        >
+          Open group <ChevronRight className="h-4 w-4 ml-1" />
+        </Button>
+        <Button
+          variant="ghost"
+          className="w-full"
+          onClick={() => {
+            setCreated(null);
+            setGroupName("");
+            setCreatorLabel("");
+          }}
+        >
+          Create another
+        </Button>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-6 mt-4">
-      <div className="flex flex-col gap-4">
-        <h3 className="text-sm font-semibold">Create a Group</h3>
-        <p className="text-xs text-muted-foreground -mt-2">
-          You need a share link to join. Create one in the "Create Link" tab
-          first.
-        </p>
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="group-name">Group name</Label>
+        <Input
+          id="group-name"
+          placeholder="e.g. CS Friends 113-2"
+          value={groupName}
+          onChange={(e) => setGroupName(e.target.value)}
+          maxLength={80}
+        />
+      </div>
 
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="group-name">Group name</Label>
-          <Input
-            id="group-name"
-            placeholder="e.g. CS Friends 113-2"
-            value={groupName}
-            onChange={(e) => setGroupName(e.target.value)}
-            maxLength={100}
-          />
-        </div>
-
+      <div className="grid grid-cols-2 gap-3">
         <div className="flex flex-col gap-2">
           <Label>Semester</Label>
-          <p className="text-sm text-muted-foreground">
-            {toPrettySemester(semester)}
-          </p>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="group-share">Attach your share link (optional)</Label>
-          {sharesLoading ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" /> Loading shares...
-            </div>
-          ) : (
-            <select
-              id="group-share"
-              className="text-sm border rounded-md p-2 bg-background"
-              value={selectedShareId}
-              onChange={(e) => setSelectedShareId(e.target.value)}
-            >
-              <option value="">None</option>
-              {semesterShares.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.displayName || toPrettySemester(s.semesters[0] ?? "")}
-                </option>
+          <Select value={groupSemester} onValueChange={setGroupSemester}>
+            <SelectTrigger className="text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {recentSemesters.map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {toPrettySemester(s.id)}
+                </SelectItem>
               ))}
-            </select>
-          )}
+            </SelectContent>
+          </Select>
         </div>
-
-        <Button
-          onClick={() => createMutation.mutate()}
-          disabled={createMutation.isPending || !groupName.trim()}
-          className="w-full"
-        >
-          {createMutation.isPending ? (
-            <>
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Creating...
-            </>
-          ) : (
-            <>
-              <Plus className="h-4 w-4 mr-2" /> Create Group
-            </>
-          )}
-        </Button>
-
-        {createdInviteUrl && (
-          <div className="flex flex-col gap-2 p-3 rounded-lg border bg-muted/30">
-            <p className="text-xs font-medium">
-              Invite link — share this with friends
-            </p>
-            <div className="flex gap-2">
-              <Input
-                value={createdInviteUrl}
-                readOnly
-                className="flex-1 font-mono text-xs"
-              />
-              <Button size="icon" variant="outline" onClick={copyCreatedUrl}>
-                {copiedCreate ? (
-                  <Check className="h-4 w-4" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
-            </div>
-          </div>
-        )}
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="creator-label">Your nickname</Label>
+          <Input
+            id="creator-label"
+            placeholder="How you appear"
+            value={creatorLabel}
+            onChange={(e) => setCreatorLabel(e.target.value)}
+            maxLength={60}
+          />
+        </div>
       </div>
 
-      <Separator />
+      <p className="text-xs text-muted-foreground -mt-1">
+        Your timetable for {toPrettySemester(groupSemester)} will be linked
+        automatically.
+      </p>
 
-      <div className="flex flex-col gap-3">
-        <h3 className="text-sm font-semibold">My Groups</h3>
-        {storedGroups.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No groups yet. Create one above.
-          </p>
+      <Button
+        className="w-full"
+        onClick={() => createMutation.mutate()}
+        disabled={!groupName.trim() || createMutation.isPending}
+      >
+        {createMutation.isPending ? (
+          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
         ) : (
-          <div className="flex flex-col gap-3">
-            {storedGroups.map((g) => {
-              const inviteUrl = `${window.location.origin}/${lang}/timetable/group/${g.code}`;
-              const isCopied = copiedGroup === g.code;
-              return (
-                <div
-                  key={g.code}
-                  className="flex items-center gap-2 p-2 rounded-lg border"
-                >
-                  <div className="flex flex-col flex-1 min-w-0">
-                    <span className="text-sm font-medium truncate">
-                      {g.name}
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      {toPrettySemester(g.semester)}
-                    </span>
-                  </div>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-7 w-7 shrink-0"
-                    onClick={() => copyInviteUrl(inviteUrl, g.code)}
-                  >
-                    {isCopied ? (
-                      <Check className="h-3.5 w-3.5" />
-                    ) : (
-                      <Copy className="h-3.5 w-3.5" />
-                    )}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-7 shrink-0"
-                    onClick={() =>
-                      navigate(`/${lang}/timetable/group/${g.code}`)
-                    }
-                  >
-                    Open
-                  </Button>
-                </div>
-              );
-            })}
-          </div>
+          <Users className="h-4 w-4 mr-2" />
         )}
-      </div>
+        Create Group
+      </Button>
     </div>
   );
 }
 
-const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
+// ── Main dialog ───────────────────────────────────────────────────────────────
+const ShareTimetableDialog = ({
+  children,
+  initialTab = "create",
+}: {
+  children: React.ReactNode;
+  initialTab?: "create" | "manage" | "groups";
+}) => {
   const [open, setOpen] = useState(false);
-  const [tab, setTab] = useState<"create" | "manage" | "groups">("create");
+  const [tab, setTab] = useState<"create" | "manage" | "groups">(initialTab);
   const [visibility, setVisibility] = useState<Visibility>("link_only");
   const [isLive, setIsLive] = useState(true);
   const [isAnonymous, setIsAnonymous] = useState(false);
@@ -403,13 +390,12 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
     Record<string, { grade?: string; difficulty?: number; attendance?: string }>
   >({});
 
-  const { courses, semester, getSemesterCourses, colorMap } =
-    useUserTimetable();
+  const { courses, semester, colorMap } = useUserTimetable();
   const { isAuthenticated } = useAuth();
   const { createShare, deleteShare, listOwnShares } = useTimetableShare();
   const queryClient = useQueryClient();
 
-  // Multi-semester selection — default to active semester
+  // Multi-semester selection
   const [selectedSemesters, setSelectedSemesters] = useState<string[]>([
     semester,
   ]);
@@ -499,8 +485,8 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
+      <DialogContent className="max-w-lg flex flex-col max-h-[90dvh] overflow-hidden">
+        <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <Share2 className="h-5 w-5" /> Share Timetable
           </DialogTitle>
@@ -516,8 +502,9 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
         <Tabs
           value={tab}
           onValueChange={(v) => setTab(v as "create" | "manage" | "groups")}
+          className="flex flex-col flex-1 min-h-0"
         >
-          <TabsList className="w-full">
+          <TabsList className="w-full shrink-0">
             <TabsTrigger value="create" className="flex-1">
               Create Link
             </TabsTrigger>
@@ -535,271 +522,266 @@ const ShareTimetableDialog = ({ children }: { children: React.ReactNode }) => {
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="create" className="flex flex-col gap-4 mt-4">
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="share-name">Name (optional)</Label>
-              <Input
-                id="share-name"
-                placeholder={`${toPrettySemester(semester)} Timetable`}
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                maxLength={100}
-              />
-            </div>
+          {/* ── Create Link tab ─────────────────────────────────────────────── */}
+          <TabsContent value="create" className="flex-1 mt-0 min-h-0">
+            <ScrollArea className="h-full max-h-[55vh] pr-1">
+              <div className="flex flex-col gap-4 py-3">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="share-name">Name (optional)</Label>
+                  <Input
+                    id="share-name"
+                    placeholder={`${toPrettySemester(semester)} Timetable`}
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    maxLength={100}
+                  />
+                </div>
 
-            {allSemestersWithCourses.length > 0 && (
-              <div className="flex flex-col gap-2">
-                <Label>Semesters</Label>
-                <div className="flex flex-wrap gap-2">
-                  {allSemestersWithCourses.map((sem) => (
-                    <button
-                      key={sem}
-                      type="button"
-                      onClick={() => toggleSemester(sem)}
-                      className={`px-3 py-1 rounded-full text-xs border transition-colors ${
-                        selectedSemesters.includes(sem)
-                          ? "bg-primary text-primary-foreground border-primary"
-                          : "bg-background border-border text-muted-foreground hover:border-foreground"
-                      }`}
+                {allSemestersWithCourses.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    <Label>Semesters</Label>
+                    <div className="flex flex-wrap gap-1.5">
+                      {allSemestersWithCourses.map((sem) => (
+                        <button
+                          key={sem}
+                          type="button"
+                          onClick={() => toggleSemester(sem)}
+                          className={`px-2.5 py-1 rounded-full text-xs border transition-colors ${
+                            selectedSemesters.includes(sem)
+                              ? "bg-primary text-primary-foreground border-primary"
+                              : "bg-background border-border text-muted-foreground hover:border-foreground"
+                          }`}
+                        >
+                          {toPrettySemester(sem)} ·{" "}
+                          {(courses[sem] ?? []).length}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <Label>Live sync</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Viewers always see your latest courses
+                      </p>
+                    </div>
+                    <Switch checked={isLive} onCheckedChange={setIsLive} />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <Label>Public gallery</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Appears in community timetable browser
+                      </p>
+                    </div>
+                    <Switch
+                      checked={visibility === "public"}
+                      onCheckedChange={(v) =>
+                        setVisibility(v ? "public" : "link_only")
+                      }
+                    />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <Label>Anonymous</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Hide your identity from viewers
+                      </p>
+                    </div>
+                    <Switch
+                      checked={isAnonymous}
+                      onCheckedChange={setIsAnonymous}
+                    />
+                  </div>
+                </div>
+
+                <Separator />
+
+                <Collapsible open={notesOpen} onOpenChange={setNotesOpen}>
+                  <CollapsibleTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-between h-8 px-2"
                     >
-                      {toPrettySemester(sem)} · {(courses[sem] ?? []).length}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
+                      <span className="text-sm">Course notes</span>
+                      {notesOpen ? (
+                        <ChevronDown className="h-4 w-4" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="flex flex-col gap-3 mt-2">
+                    <p className="text-xs text-muted-foreground">
+                      Add notes visible to anyone viewing your timetable.
+                    </p>
+                    {semesterCourses.map((c) => (
+                      <NoteEditor
+                        key={c.raw_id}
+                        courseId={c.raw_id}
+                        courseNote={courseNotes[c.raw_id] ?? ""}
+                        courseName={c.name_zh || c.name_en}
+                        onSave={(note) =>
+                          setCourseNotes((prev) => ({
+                            ...prev,
+                            [c.raw_id]: note,
+                          }))
+                        }
+                      />
+                    ))}
+                  </CollapsibleContent>
+                </Collapsible>
 
-            <div className="flex flex-col gap-3">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label>Live sync</Label>
-                  <p className="text-xs text-muted-foreground">
-                    Viewers always see your latest courses
-                  </p>
-                </div>
-                <Switch checked={isLive} onCheckedChange={setIsLive} />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label>Public gallery</Label>
-                  <p className="text-xs text-muted-foreground">
-                    Appears in community timetable browser
-                  </p>
-                </div>
-                <Switch
-                  checked={visibility === "public"}
-                  onCheckedChange={(v) =>
-                    setVisibility(v ? "public" : "link_only")
-                  }
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label>Anonymous</Label>
-                  <p className="text-xs text-muted-foreground">
-                    Hide your identity from viewers
-                  </p>
-                </div>
-                <Switch
-                  checked={isAnonymous}
-                  onCheckedChange={setIsAnonymous}
-                />
-              </div>
-            </div>
+                {visibility === "public" && (
+                  <Collapsible open={gradeMode} onOpenChange={setGradeMode}>
+                    <CollapsibleTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        className="w-full justify-between h-8 px-2"
+                      >
+                        <span className="text-sm">
+                          Grade & difficulty context
+                        </span>
+                        {gradeMode ? (
+                          <ChevronDown className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="flex flex-col gap-3 mt-2">
+                      <p className="text-xs text-muted-foreground">
+                        Help juniors understand this semester. Optional.
+                      </p>
+                      {semesterCourses.map((c) => (
+                        <div key={c.raw_id} className="flex flex-col gap-1">
+                          <span className="text-sm font-medium truncate">
+                            {c.name_zh}
+                          </span>
+                          <div className="flex gap-2">
+                            <Input
+                              placeholder="Grade (A+, A, ...)"
+                              maxLength={3}
+                              className="h-7 text-sm w-24"
+                              value={gradeContext[c.raw_id]?.grade ?? ""}
+                              onChange={(e) =>
+                                setGradeContext((prev) => ({
+                                  ...prev,
+                                  [c.raw_id]: {
+                                    ...prev[c.raw_id],
+                                    grade: e.target.value,
+                                  },
+                                }))
+                              }
+                            />
+                            <Input
+                              placeholder="Difficulty 1-5"
+                              type="number"
+                              min={1}
+                              max={5}
+                              className="h-7 text-sm w-28"
+                              value={gradeContext[c.raw_id]?.difficulty ?? ""}
+                              onChange={(e) =>
+                                setGradeContext((prev) => ({
+                                  ...prev,
+                                  [c.raw_id]: {
+                                    ...prev[c.raw_id],
+                                    difficulty: Number(e.target.value),
+                                  },
+                                }))
+                              }
+                            />
+                            <Input
+                              placeholder="Attendance"
+                              className="h-7 text-sm flex-1"
+                              value={gradeContext[c.raw_id]?.attendance ?? ""}
+                              onChange={(e) =>
+                                setGradeContext((prev) => ({
+                                  ...prev,
+                                  [c.raw_id]: {
+                                    ...prev[c.raw_id],
+                                    attendance: e.target.value,
+                                  },
+                                }))
+                              }
+                            />
+                          </div>
+                        </div>
+                      ))}
+                    </CollapsibleContent>
+                  </Collapsible>
+                )}
 
-            <Separator />
-
-            <Collapsible open={notesOpen} onOpenChange={setNotesOpen}>
-              <CollapsibleTrigger asChild>
                 <Button
-                  variant="ghost"
-                  className="w-full justify-between h-8 px-2"
+                  onClick={() => createMutation.mutate()}
+                  disabled={
+                    createMutation.isPending ||
+                    selectedSemesters.length === 0 ||
+                    allSelectedCourseIds.length === 0
+                  }
+                  className="w-full"
                 >
-                  <span className="text-sm">Course notes</span>
-                  {notesOpen ? (
-                    <ChevronDown className="h-4 w-4" />
+                  {createMutation.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />{" "}
+                      Generating...
+                    </>
                   ) : (
-                    <ChevronRight className="h-4 w-4" />
+                    <>
+                      <Link className="h-4 w-4 mr-2" /> Generate Share Link
+                    </>
                   )}
                 </Button>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="flex flex-col gap-3 mt-2">
-                <p className="text-xs text-muted-foreground">
-                  Add notes visible to anyone who views your timetable (e.g. "no
-                  attendance", "heavy workload")
-                </p>
-                {semesterCourses.map((c) => (
-                  <NoteEditor
-                    key={c.raw_id}
-                    courseId={c.raw_id}
-                    courseNote={courseNotes[c.raw_id] ?? ""}
-                    courseName={c.name_zh || c.name_en}
-                    onSave={(note) =>
-                      setCourseNotes((prev) => ({ ...prev, [c.raw_id]: note }))
-                    }
-                  />
-                ))}
-              </CollapsibleContent>
-            </Collapsible>
-
-            {visibility === "public" && (
-              <Collapsible open={gradeMode} onOpenChange={setGradeMode}>
-                <CollapsibleTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-between h-8 px-2"
-                  >
-                    <span className="text-sm">Grade & difficulty context</span>
-                    {gradeMode ? (
-                      <ChevronDown className="h-4 w-4" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4" />
-                    )}
-                  </Button>
-                </CollapsibleTrigger>
-                <CollapsibleContent className="flex flex-col gap-3 mt-2">
-                  <p className="text-xs text-muted-foreground">
-                    Help juniors understand this semester. Optional.
+                {selectedSemesters.length === 0 && (
+                  <p className="text-xs text-center text-muted-foreground">
+                    Select at least one semester
                   </p>
-                  {semesterCourses.map((c) => (
-                    <div key={c.raw_id} className="flex flex-col gap-1">
-                      <span className="text-sm font-medium truncate">
-                        {c.name_zh}
-                      </span>
-                      <div className="flex gap-2">
-                        <Input
-                          placeholder="Grade (A+, A, ...)"
-                          maxLength={3}
-                          className="h-7 text-sm w-24"
-                          value={gradeContext[c.raw_id]?.grade ?? ""}
-                          onChange={(e) =>
-                            setGradeContext((prev) => ({
-                              ...prev,
-                              [c.raw_id]: {
-                                ...prev[c.raw_id],
-                                grade: e.target.value,
-                              },
-                            }))
-                          }
-                        />
-                        <Input
-                          placeholder="Difficulty 1-5"
-                          type="number"
-                          min={1}
-                          max={5}
-                          className="h-7 text-sm w-28"
-                          value={gradeContext[c.raw_id]?.difficulty ?? ""}
-                          onChange={(e) =>
-                            setGradeContext((prev) => ({
-                              ...prev,
-                              [c.raw_id]: {
-                                ...prev[c.raw_id],
-                                difficulty: Number(e.target.value),
-                              },
-                            }))
-                          }
-                        />
-                        <Input
-                          placeholder="Attendance"
-                          className="h-7 text-sm flex-1"
-                          value={gradeContext[c.raw_id]?.attendance ?? ""}
-                          onChange={(e) =>
-                            setGradeContext((prev) => ({
-                              ...prev,
-                              [c.raw_id]: {
-                                ...prev[c.raw_id],
-                                attendance: e.target.value,
-                              },
-                            }))
-                          }
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </CollapsibleContent>
-              </Collapsible>
-            )}
-
-            <Button
-              onClick={() => createMutation.mutate()}
-              disabled={
-                createMutation.isPending ||
-                selectedSemesters.length === 0 ||
-                allSelectedCourseIds.length === 0
-              }
-              className="w-full"
-            >
-              {createMutation.isPending ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />{" "}
-                  Generating...
-                </>
-              ) : (
-                <>
-                  <Link className="h-4 w-4 mr-2" /> Generate Share Link
-                </>
-              )}
-            </Button>
-            {selectedSemesters.length === 0 && (
-              <p className="text-xs text-center text-muted-foreground">
-                Select at least one semester
-              </p>
-            )}
-            {selectedSemesters.length > 0 &&
-              allSelectedCourseIds.length === 0 && (
-                <p className="text-xs text-center text-muted-foreground">
-                  Add courses first
-                </p>
-              )}
+                )}
+                {selectedSemesters.length > 0 &&
+                  allSelectedCourseIds.length === 0 && (
+                    <p className="text-xs text-center text-muted-foreground">
+                      Add courses first
+                    </p>
+                  )}
+              </div>
+            </ScrollArea>
           </TabsContent>
 
-          <TabsContent value="manage" className="mt-4">
-            {sharesLoading ? (
-              <div className="flex justify-center py-8">
-                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              </div>
-            ) : ownShares.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground text-sm">
-                No share links yet. Create one in the "Create Link" tab.
-              </div>
-            ) : (
-              <div className="flex flex-col gap-6">
-                {ownShares.map((share) => (
-                  <div key={share.id} className="flex flex-col gap-2">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium text-sm">
-                        {share.displayName ||
-                          toPrettySemester(share.semesters[0] ?? "")}
-                      </span>
-                      {share.isLive && (
-                        <Badge variant="secondary" className="text-xs">
-                          Live
-                        </Badge>
-                      )}
-                      {share.visibility === "public" && (
-                        <Badge variant="outline" className="text-xs">
-                          <Globe className="h-2.5 w-2.5 mr-1" />
-                          Public
-                        </Badge>
-                      )}
-                    </div>
-                    <ShareLinkPanel
-                      share={{ ...share, shareUrl: "" }}
+          {/* ── My Links tab ───────────────────────────────────────────────── */}
+          <TabsContent value="manage" className="flex-1 mt-0 min-h-0">
+            <ScrollArea className="h-full max-h-[55vh] pr-1">
+              <div className="flex flex-col gap-2 py-3">
+                {sharesLoading ? (
+                  <div className="flex justify-center py-8">
+                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                  </div>
+                ) : ownShares.length === 0 ? (
+                  <div className="text-center py-8 text-muted-foreground text-sm">
+                    No share links yet. Create one in the "Create Link" tab.
+                  </div>
+                ) : (
+                  ownShares.map((share) => (
+                    <ShareListItem
+                      key={share.id}
+                      share={share}
                       onDelete={() => deleteMutation.mutate(share.id)}
                     />
-                    <Separator />
-                  </div>
-                ))}
+                  ))
+                )}
               </div>
-            )}
+            </ScrollArea>
           </TabsContent>
 
-          <TabsContent value="groups">
-            <GroupsTab
-              semester={semester}
-              ownShares={ownShares}
-              sharesLoading={sharesLoading}
-            />
+          {/* ── Groups tab ─────────────────────────────────────────────────── */}
+          <TabsContent value="groups" className="flex-1 mt-0 min-h-0">
+            <ScrollArea className="h-full max-h-[55vh] pr-1">
+              <div className="py-3">
+                <GroupsTab semester={semester} />
+              </div>
+            </ScrollArea>
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/apps/web/src/components/Timetable/TimetableCourseList.tsx
+++ b/apps/web/src/components/Timetable/TimetableCourseList.tsx
@@ -114,8 +114,10 @@ export const CourseSearchContainerDynamic = () => (
 const ShareTimetableDialogLazy = lazy(() => import("./ShareTimetableDialog"));
 export const ShareTimetableDialogDynamic = ({
   children,
+  initialTab,
 }: {
   children: React.ReactNode;
+  initialTab?: "create" | "manage" | "groups";
 }) => (
   <Suspense
     fallback={
@@ -124,7 +126,9 @@ export const ShareTimetableDialogDynamic = ({
       </Button>
     }
   >
-    <ShareTimetableDialogLazy>{children}</ShareTimetableDialogLazy>
+    <ShareTimetableDialogLazy initialTab={initialTab}>
+      {children}
+    </ShareTimetableDialogLazy>
   </Suspense>
 );
 

--- a/apps/web/src/components/Timetable/TimetableCourseList.tsx
+++ b/apps/web/src/components/Timetable/TimetableCourseList.tsx
@@ -64,17 +64,21 @@ const DownloadTimetableDialogLazy = lazy(
 );
 export const DownloadTimetableDialogDynamic = ({
   icsfileLink,
+  children,
 }: {
   icsfileLink: string;
+  children?: React.ReactNode;
 }) => (
   <Suspense
     fallback={
-      <Button variant="outline" disabled>
+      <Button variant="ghost" size="icon" className="h-8 w-8" disabled>
         <Loader2 className="w-4 h-4 animate-spin" />
       </Button>
     }
   >
-    <DownloadTimetableDialogLazy icsfileLink={icsfileLink} />
+    <DownloadTimetableDialogLazy icsfileLink={icsfileLink}>
+      {children}
+    </DownloadTimetableDialogLazy>
   </Suspense>
 );
 

--- a/apps/web/src/components/Timetable/TimetableSidebar.tsx
+++ b/apps/web/src/components/Timetable/TimetableSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Globe,
   Users,
   ChevronRight,
+  Download,
 } from "lucide-react";
 import useUserTimetable from "@/hooks/contexts/useUserTimetable";
 import { useNavigate, useParams } from "react-router-dom";
@@ -68,48 +69,33 @@ const TimetableSidebar = ({
     staleTime: 60_000,
   });
 
-  const shareLink = `https://nthumods.com/timetable/view?${Object.keys(courses)
-    .map(
-      (sem) =>
-        `semester_${sem}=${courses[sem].map((id) => encodeURI(id)).join(",")}`,
-    )
-    .join("&")}&colorMap=${encodeURIComponent(JSON.stringify(colorMap))}`;
   const apiBase = import.meta.env.VITE_COURSEWEB_API_URL;
   const icsQuery = `semester=${semester}&semester_${semester}=${(courses[semester] ?? []).map((id) => encodeURI(id)).join(",")}`;
-  const webcalLink = `${apiBase.replace(/^https?/, "webcals")}/timetable/calendar.ics?${icsQuery}`;
   const icsfileLink = `${apiBase}/timetable/calendar.ics?${icsQuery}`;
 
   const handleGroupByDepartment = (semester: string) => {
     const semesterCourses = getSemesterCourses(semester);
     const newColorMap = { ...colorMap };
-
     const departments = semesterCourses.reduce((acc, course) => {
-      if (!acc.includes(course.department)) {
-        acc.push(course.department);
-      }
+      if (!acc.includes(course.department)) acc.push(course.department);
       return acc;
     }, [] as string[]);
-
     for (let i = 0; i < departments.length; i++) {
       const color = currentColors[i % currentColors.length];
-
       semesterCourses
         .filter((course) => course.department === departments[i])
         .forEach((course) => {
           newColorMap[course.raw_id] = color;
         });
     }
-
     setColorMap(newColorMap);
   };
 
   const sortByCredits = (semester: string) => {
     const semesterCourses = getSemesterCourses(semester);
-
     const sortedCourses = [...semesterCourses].sort(
       (a, b) => b.credits - a.credits,
     );
-
     setCourses({
       ...courses,
       [semester]: sortedCourses.map((course) => course.raw_id),
@@ -117,49 +103,25 @@ const TimetableSidebar = ({
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="grid grid-cols-2 grid-rows-2 gap-2">
-        <Button variant="outline" onClick={() => setVertical(!vertical)}>
-          <Repeat className="w-4 h-4 mr-1" />{" "}
-          {vertical
-            ? dict.timetable.actions.horizontal_view
-            : dict.timetable.actions.vertical_view}
-        </Button>
-        <DownloadTimetableDialogDynamic icsfileLink={icsfileLink} />
-        <ShareTimetableDialogDynamic>
+    <div className="flex flex-col gap-3">
+      {/* Primary action — add courses */}
+      <Dialog>
+        <DialogTitle className="hidden">AddToSem</DialogTitle>
+        <DialogTrigger asChild>
           <Button variant="outline" className="w-full">
-            <Share2 className="w-4 h-4 mr-1" />
-            Share
+            <Plus className="w-4 h-4 mr-2" />
+            {dict.course.item.add_to_semester}
           </Button>
-        </ShareTimetableDialogDynamic>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline">
-              <EllipsisVertical className="w-4 h-4 mr-2" />
-              {dict.timetable.actions.more_options}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuLabel>Customizations</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => handleGroupByDepartment(semester)}>
-              {dict.timetable.actions.group_dept}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => sortByCredits(semester)}>
-              {dict.timetable.actions.sort_by_credits}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      <Button
-        variant="ghost"
-        className="w-full justify-start"
-        onClick={() => navigate(`/${lang}/timetable/community`)}
-      >
-        <Globe className="w-4 h-4 mr-2" />
-        Community Timetables
-      </Button>
+        </DialogTrigger>
+        <DialogContent className="p-0 h-[100dvh] max-w-screen w-screen gap-0 px-2 pt-6 md:p-8">
+          <CourseSearchContainerDynamic />
+        </DialogContent>
+      </Dialog>
 
+      {/* Course list — the main content */}
+      <TimetableCourseList semester={semester} vertical={vertical} />
+
+      {/* Groups section — only when signed in */}
       {isAuthenticated && (
         <div className="flex flex-col gap-1">
           <div className="flex items-center justify-between px-1">
@@ -211,19 +173,72 @@ const TimetableSidebar = ({
         </div>
       )}
 
-      <Dialog>
-        <DialogTitle className="hidden">AddToSem</DialogTitle>
-        <DialogTrigger asChild>
-          <Button variant="outline">
-            <Plus className="w-4 h-4 mr-2" />
-            {dict.course.item.add_to_semester}
+      {/* Utility action row + community link */}
+      <div className="flex items-center gap-1 pt-1 border-t">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title={
+            vertical
+              ? dict.timetable.actions.horizontal_view
+              : dict.timetable.actions.vertical_view
+          }
+          onClick={() => setVertical(!vertical)}
+        >
+          <Repeat className="w-4 h-4" />
+        </Button>
+
+        <DownloadTimetableDialogDynamic icsfileLink={icsfileLink}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            title="Download / export"
+          >
+            <Download className="w-4 h-4" />
           </Button>
-        </DialogTrigger>
-        <DialogContent className="p-0 h-[100dvh] max-w-screen w-screen gap-0 px-2 pt-6 md:p-8">
-          <CourseSearchContainerDynamic />
-        </DialogContent>
-      </Dialog>
-      <TimetableCourseList semester={semester} vertical={vertical} />
+        </DownloadTimetableDialogDynamic>
+
+        <ShareTimetableDialogDynamic>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            title="Share timetable"
+          >
+            <Share2 className="w-4 h-4" />
+          </Button>
+        </ShareTimetableDialogDynamic>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <EllipsisVertical className="w-4 h-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuLabel>Customizations</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => handleGroupByDepartment(semester)}>
+              {dict.timetable.actions.group_dept}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => sortByCredits(semester)}>
+              {dict.timetable.actions.sort_by_credits}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <button
+          type="button"
+          onClick={() => navigate(`/${lang}/timetable/community`)}
+          className="ml-auto flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <Globe className="w-3 h-3" />
+          Community
+        </button>
+      </div>
+
       <OpenCollectiveSponsorBanner />
     </div>
   );

--- a/apps/web/src/components/Timetable/TimetableSidebar.tsx
+++ b/apps/web/src/components/Timetable/TimetableSidebar.tsx
@@ -1,6 +1,6 @@
-import { Repeat, Plus, EllipsisVertical, Share2 } from "lucide-react";
+import { Repeat, Plus, EllipsisVertical, Share2, Globe } from "lucide-react";
 import useUserTimetable from "@/hooks/contexts/useUserTimetable";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import useDictionary from "@/dictionaries/useDictionary";
 import { Button } from "@courseweb/ui";
 import {
@@ -46,6 +46,7 @@ const TimetableSidebar = ({
   } = useUserTimetable();
 
   const navigate = useNavigate();
+  const { lang } = useParams<{ lang: string }>();
 
   const shareLink = `https://nthumods.com/timetable/view?${Object.keys(courses)
     .map(
@@ -130,6 +131,14 @@ const TimetableSidebar = ({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+      <Button
+        variant="ghost"
+        className="w-full justify-start"
+        onClick={() => navigate(`/${lang}/community`)}
+      >
+        <Globe className="w-4 h-4 mr-2" />
+        Community Timetables
+      </Button>
       <Dialog>
         <DialogTitle className="hidden">AddToSem</DialogTitle>
         <DialogTrigger asChild>

--- a/apps/web/src/components/Timetable/TimetableSidebar.tsx
+++ b/apps/web/src/components/Timetable/TimetableSidebar.tsx
@@ -134,7 +134,7 @@ const TimetableSidebar = ({
       <Button
         variant="ghost"
         className="w-full justify-start"
-        onClick={() => navigate(`/${lang}/community`)}
+        onClick={() => navigate(`/${lang}/timetable/community`)}
       >
         <Globe className="w-4 h-4 mr-2" />
         Community Timetables

--- a/apps/web/src/components/Timetable/TimetableSidebar.tsx
+++ b/apps/web/src/components/Timetable/TimetableSidebar.tsx
@@ -1,4 +1,12 @@
-import { Repeat, Plus, EllipsisVertical, Share2, Globe } from "lucide-react";
+import {
+  Repeat,
+  Plus,
+  EllipsisVertical,
+  Share2,
+  Globe,
+  Users,
+  ChevronRight,
+} from "lucide-react";
 import useUserTimetable from "@/hooks/contexts/useUserTimetable";
 import { useNavigate, useParams } from "react-router-dom";
 import useDictionary from "@/dictionaries/useDictionary";
@@ -24,6 +32,10 @@ import {
   DropdownMenuTrigger,
 } from "@courseweb/ui";
 import OpenCollectiveSponsorBanner from "../Sponsorship/OpenCollectiveSponsorBanner";
+import { useAuth } from "react-oidc-context";
+import { useQuery } from "@tanstack/react-query";
+import { useTimetableShare } from "@/hooks/useTimetableShare";
+import { toPrettySemester } from "@/helpers/semester";
 
 const TimetableSidebar = ({
   vertical,
@@ -47,6 +59,14 @@ const TimetableSidebar = ({
 
   const navigate = useNavigate();
   const { lang } = useParams<{ lang: string }>();
+  const { isAuthenticated } = useAuth();
+  const { listMyGroups } = useTimetableShare();
+  const { data: myGroups = [] } = useQuery({
+    queryKey: ["my-groups"],
+    queryFn: listMyGroups,
+    enabled: isAuthenticated,
+    staleTime: 60_000,
+  });
 
   const shareLink = `https://nthumods.com/timetable/view?${Object.keys(courses)
     .map(
@@ -139,6 +159,58 @@ const TimetableSidebar = ({
         <Globe className="w-4 h-4 mr-2" />
         Community Timetables
       </Button>
+
+      {isAuthenticated && (
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center justify-between px-1">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Groups
+            </span>
+            <ShareTimetableDialogDynamic initialTab="groups">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                title="Create a group"
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </Button>
+            </ShareTimetableDialogDynamic>
+          </div>
+          {myGroups.length === 0 ? (
+            <ShareTimetableDialogDynamic initialTab="groups">
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground px-1 py-1 text-left transition-colors"
+              >
+                + Create or join a group
+              </button>
+            </ShareTimetableDialogDynamic>
+          ) : (
+            myGroups.map((group) => (
+              <button
+                key={group.id}
+                type="button"
+                className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent transition-colors text-left w-full"
+                onClick={() =>
+                  navigate(`/${lang}/timetable/group/${group.inviteCode}`)
+                }
+              >
+                <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="flex-1 min-w-0">
+                  <span className="text-sm truncate block">{group.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {toPrettySemester(group.semester)} · {group.members.length}{" "}
+                    member{group.members.length !== 1 ? "s" : ""}
+                  </span>
+                </span>
+                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              </button>
+            ))
+          )}
+        </div>
+      )}
+
       <Dialog>
         <DialogTitle className="hidden">AddToSem</DialogTitle>
         <DialogTrigger asChild>

--- a/apps/web/src/const/apps.ts
+++ b/apps/web/src/const/apps.ts
@@ -9,6 +9,7 @@ import {
   SquareGanttChart,
   Sparkles,
   Dumbbell,
+  Users,
 } from "lucide-react";
 
 export const categories: {
@@ -99,6 +100,14 @@ export const apps: {
     title_en: "Calendar",
     href: "/calendar",
     Icon: CalendarIcon,
+  },
+  {
+    id: "timetable-community",
+    category: "course",
+    title_zh: "社群課表",
+    title_en: "Community Timetables",
+    href: "/timetable/community",
+    Icon: Users,
   },
   {
     id: "clubs_info",

--- a/apps/web/src/hooks/useTimetableShare.ts
+++ b/apps/web/src/hooks/useTimetableShare.ts
@@ -216,11 +216,30 @@ export function useTimetableShare() {
     [authHeaders],
   );
 
+  const listMyGroups = useCallback(async (): Promise<TimetableGroup[]> => {
+    const res = await fetch(`${API_BASE}/timetable-share/groups`, {
+      headers: authHeaders,
+    });
+    return parseResponse<TimetableGroup[]>(res);
+  }, [authHeaders]);
+
+  const deleteGroup = useCallback(
+    async (code: string): Promise<void> => {
+      const res = await fetch(`${API_BASE}/timetable-share/group/${code}`, {
+        method: "DELETE",
+        headers: authHeaders,
+      });
+      await parseResponse(res);
+    },
+    [authHeaders],
+  );
+
   const createGroup = useCallback(
     async (data: {
       name: string;
       semester: string;
       sharedTimetableId?: string;
+      creatorLabel?: string;
     }): Promise<TimetableGroup> => {
       const res = await fetch(`${API_BASE}/timetable-share/group`, {
         method: "POST",
@@ -270,6 +289,7 @@ export function useTimetableShare() {
     getPublicGallery,
     getGroup,
     listOwnShares,
+    listMyGroups,
     createShare,
     updateShare,
     deleteShare,
@@ -278,6 +298,7 @@ export function useTimetableShare() {
     updateSaved,
     unsaveShare,
     createGroup,
+    deleteGroup,
     joinGroup,
     leaveGroup,
   };

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -420,7 +420,7 @@ export const router = createBrowserRouter([
                 handle: { title: "Shared Timetable", noindex: true },
               },
               {
-                path: "community",
+                path: "timetable/community",
                 element: <CommunityPage />,
                 handle: {
                   title: "Community Timetables",
@@ -432,7 +432,7 @@ export const router = createBrowserRouter([
                 },
               },
               {
-                path: "group/:code",
+                path: "timetable/group/:code",
                 element: <GroupViewPage />,
                 handle: { title: "Timetable Group", noindex: true },
               },

--- a/services/api/src/timetable-share.ts
+++ b/services/api/src/timetable-share.ts
@@ -430,6 +430,44 @@ const app = new Hono<{ Bindings: Bindings }>()
     return c.json({ ok: true });
   })
 
+  // ── Auth: list groups I'm a member of ────────────────────────────────────────
+  .get("/groups", auth(["calendar"]), async (c) => {
+    const userId = c.get("user").sub!;
+    const prisma = await prismaClients.fetch(c.env.DB);
+
+    const allGroups = await prisma.timetableGroup.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+
+    const myGroups = allGroups.filter((g) => {
+      const members: Array<{ userId: string }> = JSON.parse(g.members);
+      return members.some((m) => m.userId === userId);
+    });
+
+    return c.json(
+      myGroups.map((g) => ({ ...g, members: JSON.parse(g.members) })),
+    );
+  })
+
+  // ── Auth: delete group (creator only) ─────────────────────────────────────────
+  .delete("/group/:code", auth(["calendar"]), async (c) => {
+    const userId = c.get("user").sub!;
+    const { code } = c.req.param();
+    const prisma = await prismaClients.fetch(c.env.DB);
+
+    const group = await prisma.timetableGroup.findUnique({
+      where: { inviteCode: code },
+    });
+    if (!group) throw new HTTPException(404, { message: "Group not found" });
+    if (group.createdBy !== userId)
+      throw new HTTPException(403, {
+        message: "Only the creator can delete this group",
+      });
+
+    await prisma.timetableGroup.delete({ where: { id: group.id } });
+    return c.json({ ok: true });
+  })
+
   // ── Auth: create group ────────────────────────────────────────────────────────
   .post(
     "/group",
@@ -440,11 +478,13 @@ const app = new Hono<{ Bindings: Bindings }>()
         name: z.string().min(1).max(80),
         semester: z.string().length(5),
         sharedTimetableId: z.string().length(8).optional(),
+        creatorLabel: z.string().max(60).optional(),
       }),
     ),
     async (c) => {
       const userId = c.get("user").sub!;
-      const { name, semester, sharedTimetableId } = c.req.valid("json");
+      const { name, semester, sharedTimetableId, creatorLabel } =
+        c.req.valid("json");
       const prisma = await prismaClients.fetch(c.env.DB);
 
       // Verify share belongs to user if provided
@@ -463,7 +503,7 @@ const app = new Hono<{ Bindings: Bindings }>()
             {
               userId,
               sharedTimetableId,
-              label: "Creator",
+              label: creatorLabel ?? "Creator",
               joinedAt: new Date().toISOString(),
             },
           ])

--- a/services/secure-api/docker-compose.yaml
+++ b/services/secure-api/docker-compose.yaml
@@ -3,4 +3,16 @@ services:
     image: ghcr.io/nthumodifications/courseweb-secure-api:latest
     ports:
       - "5002:5002"
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${PORT:-5002}
+      DATABASE_URL: ${DATABASE_URL:-}
+      FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID:-}
+      FIREBASE_CLIENT_EMAIL: ${FIREBASE_CLIENT_EMAIL:-}
+      FIREBASE_PRIVATE_KEY: ${FIREBASE_PRIVATE_KEY:-}
+      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:-}
+      OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET:-}
+      OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI:-}
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
     restart: unless-stopped

--- a/services/secure-api/src/config/supabase.ts
+++ b/services/secure-api/src/config/supabase.ts
@@ -1,8 +1,10 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabase = createClient(
-  process.env["SUPABASE_URL"] ?? "",
-  process.env["SUPABASE_SERVICE_ROLE_KEY"] ?? "",
-);
+const url = process.env["SUPABASE_URL"];
+const key = process.env["SUPABASE_SERVICE_ROLE_KEY"];
+if (!url) throw new Error("SUPABASE_URL env var is not set");
+if (!key) throw new Error("SUPABASE_SERVICE_ROLE_KEY env var is not set");
+
+const supabase = createClient(url, key);
 
 export default supabase;


### PR DESCRIPTION
## Summary

- **Share dialog**: redesigned with max-h + ScrollArea per tab (no more viewport overflow), QR code hidden behind toggle, compact collapsible link list, Groups tab with semester picker + nickname + auto-create share on submit
- **Groups as first-class feature**: persistent Groups section in TimetableSidebar fetches membership from server (GET /groups), lists groups with navigate-on-click; join/leave/create all invalidate the sidebar list immediately
- **Group creator controls**: DELETE /group/:code endpoint (creator-only); Delete button appears when createdBy === currentUserId
- **Multi-semester sharing**: semester pill toggles in Create Link tab; community preview dialog has a semester switcher per share
- **Color fix**: community/share previews were passing {} as colorMap, overriding default theme-color generation — removed so colorMapFromCourses runs correctly
- **Sidebar redesign**: Add courses at top, course list primary, Groups compact, utility actions (rotate/download/share/more) as icon row at bottom, Community as a small text link
- **Community page**: tighter layout, denser grid; SelectItem empty-string crash fixed
- **Member nickname**: label stored per-member; creator label configurable at group creation
- **Backend**: GET /groups, DELETE /group/:code, POST /group with creatorLabel

## Test plan

- [ ] Share dialog does not overflow viewport; scroll works within each tab
- [ ] QR code hidden behind toggle, not always open
- [ ] Create group: semester picker + nickname, redirects to group page, sidebar updates
- [ ] Sidebar groups list: navigates to group page, + opens dialog on Groups tab
- [ ] Join/leave group: sidebar list updates immediately
- [ ] Creator sees Delete button; deletion removes from sidebar and navigates back
- [ ] Community preview: semester switcher works for multi-semester shares; courses have theme colors not gray
- [ ] Download icon in sidebar opens download dialog

Generated with [Claude Code](https://claude.com/claude-code)