### PR TITLE
fix(sports): browser headers for PDF fetch, smart debounce, PDF fallback link

### DIFF
--- a/apps/web/src/app/[lang]/(mods-pages)/sports-venues/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/sports-venues/page.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   RefreshCw,
   Loader2,
+  ExternalLink,
 } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@courseweb/ui";
 import { useState } from "react";
@@ -333,9 +334,35 @@ const ScheduleSheet = ({
                 {schedule.hours.notes}
               </p>
             )}
+            {schedule.pdf_url && (
+              <a
+                href={schedule.pdf_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-flex items-center gap-1 text-xs text-slate-400 hover:text-nthu-500 transition-colors"
+              >
+                <ExternalLink className="w-3 h-3" />
+                原始 PDF
+              </a>
+            )}
           </>
         ) : (
-          <p className="text-sm text-slate-400">Schedule not yet available.</p>
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-slate-400">
+              Schedule not yet available.
+            </p>
+            {schedule?.pdf_url && (
+              <a
+                href={schedule.pdf_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-nthu-500 hover:underline"
+              >
+                <ExternalLink className="w-4 h-4" />
+                View original PDF
+              </a>
+            )}
+          </div>
         )}
       </SheetContent>
     </Sheet>

--- a/services/api/src/scheduled/peo-opening-times.ts
+++ b/services/api/src/scheduled/peo-opening-times.ts
@@ -54,7 +54,13 @@ async function parsePdfWithGemini(
   apiKey: string,
 ): Promise<{ name_en: string; hours: DaySchedule } | null> {
   try {
-    const response = await fetch(pdfUrl);
+    const response = await fetch(pdfUrl, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        Referer: PEO_PAGE_URL,
+      },
+    });
     if (!response.ok) return null;
 
     const pdfBuffer = await response.arrayBuffer();

--- a/services/api/src/sports.ts
+++ b/services/api/src/sports.ts
@@ -58,14 +58,24 @@ const app = new Hono<{ Bindings: Bindings }>()
         const cached: PeoOpeningTimesCache = JSON.parse(existing.data);
         const ageMs = Date.now() - new Date(cached.lastUpdated).getTime();
         if (ageMs < 5 * 60 * 1000) {
-          return c.json(
-            {
-              ok: false,
-              reason: "recently_updated",
-              lastUpdated: cached.lastUpdated,
-            },
-            429,
-          );
+          // Bypass debounce if the target semester has never been parsed
+          const semesterHasData = semester
+            ? cached.facilities.some((f) =>
+                f.schedules.some(
+                  (s) => s.semester === semester && s.hours !== null,
+                ),
+              )
+            : true;
+          if (semesterHasData) {
+            return c.json(
+              {
+                ok: false,
+                reason: "recently_updated",
+                lastUpdated: cached.lastUpdated,
+              },
+              429,
+            );
+          }
         }
       } catch {}
     }


### PR DESCRIPTION
## Summary

Follow-up to #827.

- **Fix PDF 403s**: The NTHU PEO site blocks server-side PDF fetches without browser headers. Add `User-Agent` + `Referer: <PEO page>` to every PDF fetch in the AI scraper — confirmed working against all semester PDFs including 暑假.
- **Smart debounce bypass**: The 5-minute refresh cooldown now skips when the requested semester has `hours=null` across all facilities (never successfully parsed), so users can retry immediately instead of being stuck on unparsed data.
- **PDF fallback link**: Schedule sheet now shows a small "原始 PDF" link below parsed hours, and a prominent "View original PDF" link when hours are not yet available.

## Test plan

- [ ] Trigger `POST /sports/refresh?semester=暑假` — 暑假 schedules should populate (previously all null due to 403)
- [ ] Click refresh within 5 min on a semester that already has data → gets 429, button re-enables
- [ ] Click refresh within 5 min on 暑假 (still null) → bypasses debounce, re-parses
- [ ] Open any facility sheet → "原始 PDF" link visible below schedule; clicking opens the PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)