### PR TITLE
fix(sports): PDF fetch headers, array parsing, gemini-3.5-flash, PDF fallback link

### DIFF
--- a/apps/web/src/app/[lang]/(mods-pages)/sports-venues/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/sports-venues/page.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   RefreshCw,
   Loader2,
+  ExternalLink,
 } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@courseweb/ui";
 import { useState } from "react";
@@ -333,9 +334,35 @@ const ScheduleSheet = ({
                 {schedule.hours.notes}
               </p>
             )}
+            {schedule.pdf_url && (
+              <a
+                href={schedule.pdf_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-flex items-center gap-1 text-xs text-slate-400 hover:text-nthu-500 transition-colors"
+              >
+                <ExternalLink className="w-3 h-3" />
+                原始 PDF
+              </a>
+            )}
           </>
         ) : (
-          <p className="text-sm text-slate-400">Schedule not yet available.</p>
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-slate-400">
+              Schedule not yet available.
+            </p>
+            {schedule?.pdf_url && (
+              <a
+                href={schedule.pdf_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-nthu-500 hover:underline"
+              >
+                <ExternalLink className="w-4 h-4" />
+                View original PDF
+              </a>
+            )}
+          </div>
         )}
       </SheetContent>
     </Sheet>

--- a/services/api/src/ai/summarize.ts
+++ b/services/api/src/ai/summarize.ts
@@ -132,7 +132,7 @@ const app = new Hono<{ Bindings: Bindings }>().get(
       : "你是課程分析師。請根據提供的課程資訊，簡潔準確地摘要。用繁體中文回答。以學生視角撰寫，直接切入重點。";
 
     const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash",
+      model: "gemini-3.5-flash",
       contents: [{ role: "user", parts }],
       config: {
         systemInstruction,

--- a/services/api/src/chat/gemini.ts
+++ b/services/api/src/chat/gemini.ts
@@ -23,7 +23,7 @@ export async function* streamChat(
   data?: unknown;
 }> {
   const ai = new GoogleGenAI({ apiKey: options.apiKey });
-  const model = options.model || "gemini-2.5-flash";
+  const model = options.model || "gemini-3.5-flash";
 
   // Build system prompt with user context
   const systemPrompt = buildSystemPrompt(userContext);

--- a/services/api/src/chat/gemini.ts
+++ b/services/api/src/chat/gemini.ts
@@ -23,7 +23,7 @@ export async function* streamChat(
   data?: unknown;
 }> {
   const ai = new GoogleGenAI({ apiKey: options.apiKey });
-  const model = options.model || "gemini-2.0-flash";
+  const model = options.model || "gemini-2.5-flash";
 
   // Build system prompt with user context
   const systemPrompt = buildSystemPrompt(userContext);

--- a/services/api/src/scheduled/peo-opening-times.ts
+++ b/services/api/src/scheduled/peo-opening-times.ts
@@ -54,7 +54,13 @@ async function parsePdfWithGemini(
   apiKey: string,
 ): Promise<{ name_en: string; hours: DaySchedule } | null> {
   try {
-    const response = await fetch(pdfUrl);
+    const response = await fetch(pdfUrl, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        Referer: PEO_PAGE_URL,
+      },
+    });
     if (!response.ok) return null;
 
     const pdfBuffer = await response.arrayBuffer();

--- a/services/api/src/scheduled/peo-opening-times.ts
+++ b/services/api/src/scheduled/peo-opening-times.ts
@@ -70,7 +70,7 @@ async function parsePdfWithGemini(
 
     const ai = new GoogleGenAI({ apiKey });
     const result = await ai.models.generateContent({
-      model: "gemini-2.5-flash",
+      model: "gemini-3.5-flash",
       contents: [
         {
           role: "user",

--- a/services/api/src/scheduled/peo-opening-times.ts
+++ b/services/api/src/scheduled/peo-opening-times.ts
@@ -66,9 +66,11 @@ async function parsePdfWithGemini(
     const pdfBuffer = await response.arrayBuffer();
     const base64Data = arrayBufferToBase64(pdfBuffer);
 
+    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+
     const ai = new GoogleGenAI({ apiKey });
     const result = await ai.models.generateContent({
-      model: "gemini-2.0-flash",
+      model: "gemini-2.5-flash",
       contents: [
         {
           role: "user",
@@ -81,6 +83,7 @@ async function parsePdfWithGemini(
             },
             {
               text: `This is an opening hours schedule PDF for the NTHU (National Tsing Hua University) sports facility: "${facilityNameZh}".
+Today's date is ${today}.
 
 STEP 1 — List ALL distinct time periods found anywhere in the PDF in chronological order
          (e.g. "09:10-09:40", "09:40-10:20", "13:00-14:00", ...).
@@ -90,7 +93,10 @@ STEP 2 — For each day of the week, determine which of those time periods repre
          EXCLUDE: reserved sessions (預約/借場), cleaning (清潔/消毒),
          maintenance (維修/維護), or anything not open to the general public.
 
-Return ONLY this JSON object:
+If the PDF contains multiple date-range blocks, use the block that contains today's date.
+If today's date is not covered, use the nearest upcoming block.
+
+Return ONLY a single JSON object (not an array):
 {
   "name_en": "English name of the facility",
   "time_periods": ["HH:MM-HH:MM", ...],
@@ -122,7 +128,10 @@ Rules:
 
     const text = result.text;
     if (!text) return null;
-    const parsed = JSON.parse(text);
+    const raw = JSON.parse(text);
+    // Handle array response (model may return one object per date-range block)
+    const parsed = Array.isArray(raw) ? raw[0] : raw;
+    if (!parsed || typeof parsed !== "object") return null;
     const { name_en, ...rawHours } = parsed;
     const toSlots = (v: unknown): TimeSlot[] => {
       if (!Array.isArray(v)) return [];

--- a/services/api/src/sports.ts
+++ b/services/api/src/sports.ts
@@ -58,14 +58,24 @@ const app = new Hono<{ Bindings: Bindings }>()
         const cached: PeoOpeningTimesCache = JSON.parse(existing.data);
         const ageMs = Date.now() - new Date(cached.lastUpdated).getTime();
         if (ageMs < 5 * 60 * 1000) {
-          return c.json(
-            {
-              ok: false,
-              reason: "recently_updated",
-              lastUpdated: cached.lastUpdated,
-            },
-            429,
-          );
+          // Bypass debounce if the target semester has never been parsed
+          const semesterHasData = semester
+            ? cached.facilities.some((f) =>
+                f.schedules.some(
+                  (s) => s.semester === semester && s.hours !== null,
+                ),
+              )
+            : true;
+          if (semesterHasData) {
+            return c.json(
+              {
+                ok: false,
+                reason: "recently_updated",
+                lastUpdated: cached.lastUpdated,
+              },
+              429,
+            );
+          }
         }
       } catch {}
     }


### PR DESCRIPTION
## Summary

- **Browser headers for PDF fetch**: NTHU PEO site returns 403 without `User-Agent` + `Referer`. Adding them allows the scraper to download all semester PDFs including 暑假.
- **Gemini model upgrade**: `gemini-2.0-flash` is deprecated (404). All AI services (PDF scraper, chat, syllabus summarizer) now use `gemini-3.5-flash`, the latest stable model on the API key.
- **Array response fix**: Summer PDFs contain multiple date-range blocks. The model was returning a JSON array; prompt now requests a single object for today's date, with an `Array.isArray` guard as fallback.
- **Smart debounce bypass**: Refresh cooldown is skipped when the target semester has never been parsed (`hours=null`), so users can retry immediately.
- **PDF fallback link**: Schedule sheet shows "原始 PDF" below parsed hours, and "View original PDF" prominently when hours are unavailable.

## Test plan

- [ ] `POST /sports/refresh?semester=暑假` — 暑假 schedules populate (previously all null due to 403 + deprecated model)
- [ ] Refresh a semester that already has data → 429 within 5 min
- [ ] Refresh 暑假 (still null) within 5 min → bypasses debounce, re-parses
- [ ] Open facility sheet → "原始 PDF" link visible; clicking opens PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)