### PR TITLE
fix(sports): global refresh button + fix newline filter zeroing facilities

### DIFF
--- a/apps/web/src/app/[lang]/(mods-pages)/sports-venues/page.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/sports-venues/page.tsx
@@ -375,6 +375,26 @@ const SportsVenuesPage = () => {
   const now = useTime(60_000); // refresh every minute for status badges
   const [selectedFacility, setSelectedFacility] =
     useState<FacilitySchedule | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleGlobalRefresh = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_COURSEWEB_API_URL}/sports/refresh`,
+        { method: "POST" },
+      );
+      if (res.ok || res.status === 202) {
+        setTimeout(() => {
+          queryClient.invalidateQueries({ queryKey: ["sports-opening-times"] });
+        }, 30_000);
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  };
 
   const { data: occupancy, dataUpdatedAt } = useQuery<OccupancyItem[]>({
     queryKey: ["venue-occupancy"],
@@ -428,16 +448,30 @@ const SportsVenuesPage = () => {
         <h1 className="text-base font-semibold text-slate-800 dark:text-neutral-100">
           體育館場
         </h1>
-        {dataUpdatedAt > 0 && (
-          <span className="text-xs text-slate-400">
-            更新於{" "}
-            {new Date(dataUpdatedAt).toLocaleTimeString("zh-TW", {
-              hour: "2-digit",
-              minute: "2-digit",
-              second: "2-digit",
-            })}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {dataUpdatedAt > 0 && (
+            <span className="text-xs text-slate-400">
+              更新於{" "}
+              {new Date(dataUpdatedAt).toLocaleTimeString("zh-TW", {
+                hour: "2-digit",
+                minute: "2-digit",
+                second: "2-digit",
+              })}
+            </span>
+          )}
+          <button
+            onClick={handleGlobalRefresh}
+            disabled={refreshing}
+            title="Refresh schedule cache"
+            className="p-1 text-slate-400 hover:text-nthu-500 disabled:opacity-50 transition-colors"
+          >
+            {refreshing ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <RefreshCw className="w-4 h-4" />
+            )}
+          </button>
+        </div>
       </div>
 
       {/* Venue list */}

--- a/services/api/src/scheduled/peo-opening-times.ts
+++ b/services/api/src/scheduled/peo-opening-times.ts
@@ -192,11 +192,9 @@ export async function syncPeoOpeningTimes(
     const cells = rows[i].querySelectorAll("td");
     if (cells.length < 2) continue;
 
-    const rawName = cells[0].textContent ?? "";
-    // Layout/header cells have internal newlines; real facility names are single-line
-    if (rawName.includes("\n")) continue;
-    const name_zh = rawName.trim();
-    if (!name_zh) continue;
+    const name_zh = (cells[0].textContent ?? "").trim();
+    // Layout/header cells have internal newlines after trimming; real names don't
+    if (!name_zh || name_zh.includes("\n")) continue;
 
     // Semester PDF links are each in their own <td> — collect from all cells after the name
     const links: any[] = [];


### PR DESCRIPTION
## Changes

**1. Fix newline filter that wiped all facilities**
The previous HTML parsing fix checked `rawName.includes("\n")` before `trim()`. But linkedom includes leading/trailing whitespace from HTML indentation in `textContent`, so every real facility cell also had a newline — filtering everything out and producing 0 facilities after every sync. Fixed by trimming first, then checking for internal newlines.

**2. Global refresh button in page header**
The per-venue refresh button is inside ScheduleSheet, which can't be opened when facilities = 0 (no facility match → no sheet). Added a page-level refresh button in the header that is always visible.

Generated with [Claude Code](https://claude.com/claude-code)