### PR TITLE
Fix PDF year extraction to handle nested HTML tags

### DIFF
--- a/services/api/src/graduation/scraper.ts
+++ b/services/api/src/graduation/scraper.ts
@@ -132,12 +132,18 @@ export async function scrapeCollegePage(
     // Remaining cells contain year links
     for (let i = 1; i < cells.length; i++) {
       const pdfPattern =
-        /<a[^>]*href=["']([^"']*\.pdf[^"']*)["'][^>]*>(\d{2,3})[^<]*<\/a>/gi;
+        /<a[^>]*href=["']([^"']*\.pdf[^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi;
       let pdfMatch;
 
       while ((pdfMatch = pdfPattern.exec(cells[i])) !== null) {
         let pdfUrl = pdfMatch[1];
-        const year = pdfMatch[2];
+        // Year digits may be wrapped in nested <span>/<font> tags rather
+        // than being direct text, so strip tags before matching.
+        const yearMatch = pdfMatch[2]
+          .replace(/<[^>]+>/g, "")
+          .match(/(\d{2,3})/);
+        if (!yearMatch) continue;
+        const year = yearMatch[1];
 
         if (pdfUrl.startsWith("/")) {
           pdfUrl = BASE_URL + pdfUrl;
@@ -172,13 +178,17 @@ export async function scrapeCollegePage(
       const sectionContent = sectionMatch[3];
 
       const pdfPattern =
-        /<a[^>]*href=["']([^"']*\.pdf[^"']*)["'][^>]*>(\d{2,3})[^<]*[入學]*[年度]*<\/a>/gi;
+        /<a[^>]*href=["']([^"']*\.pdf[^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi;
       const years: YearInfo[] = [];
       let pdfMatch;
 
       while ((pdfMatch = pdfPattern.exec(sectionContent)) !== null) {
         let pdfUrl = pdfMatch[1];
-        const year = pdfMatch[2];
+        const yearMatch = pdfMatch[2]
+          .replace(/<[^>]+>/g, "")
+          .match(/(\d{2,3})/);
+        if (!yearMatch) continue;
+        const year = yearMatch[1];
 
         if (pdfUrl.startsWith("/")) {
           pdfUrl = BASE_URL + pdfUrl;


### PR DESCRIPTION
## Summary
Updated the PDF scraper to correctly extract year values from PDF links even when the year digits are wrapped in nested HTML tags (e.g., `<span>`, `<font>`).

## Key Changes
- Modified regex patterns in two locations to capture all content between anchor tags using `[\s\S]*?` instead of just direct text
- Added HTML tag stripping logic before extracting year digits using `.replace(/<[^>]+>/g, "")`
- Implemented fallback handling with `if (!yearMatch) continue;` to skip entries where year extraction fails
- Applied the same fix to both the college page scraper (line 132) and the section-based scraper (line 178)

## Implementation Details
The previous regex patterns assumed year digits would be direct text content within anchor tags. However, some PDF links have the year wrapped in nested tags like `<a href="..."><span>23</span></a>`. The fix:
1. Captures all content between `<a>` and `</a>` tags
2. Strips all HTML tags from the captured content
3. Extracts the 2-3 digit year from the cleaned text
4. Gracefully skips entries if no valid year is found

This makes the scraper more robust against variations in HTML structure while maintaining backward compatibility with previously working formats.

https://claude.ai/code/session_01HL9uYgqNGwt6odb9HjkdVm