### PR TITLE
perf(search): match courses in Postgres, unblock secure-api image build

### DIFF
--- a/services/api/src/search-fallback.ts
+++ b/services/api/src/search-fallback.ts
@@ -260,26 +260,60 @@ const createCourseQuery = (
     .range(0, MAX_SCAN_ROWS - 1);
 };
 
+/**
+ * `search_courses` is an existing database function that matches through the
+ * PGroonga indexes on the course name and teacher columns. Those indexes
+ * tokenize CJK correctly and cover the `text[]` teacher columns, which
+ * PostgREST cannot express with `ilike` at all.
+ *
+ * Matching in the database also removes the unfiltered bounded scan this
+ * previously needed to find teacher matches, which fetched up to
+ * MAX_SCAN_ROWS full rows on every keystroke.
+ */
+const loadCoursesByRpc = (
+  c: Parameters<typeof supabase_server>[0],
+  keyword: string,
+) =>
+  supabase_server(c)
+    .rpc("search_courses", { keyword })
+    .order("raw_id", { ascending: false })
+    .range(0, MAX_SCAN_ROWS - 1);
+
 const loadCourses = async (
   c: Parameters<typeof supabase_server>[0],
   query: string,
 ) => {
-  // PostgREST cannot apply `ilike` to text[] columns such as teacher_zh. The
-  // scalar `.or(...)` query narrows the common case, while the bounded scan
-  // supplies teacher matches that PostgREST cannot express safely.
-  const requests = query.trim()
-    ? [createCourseQuery(c, query), createCourseQuery(c)]
-    : [createCourseQuery(c)];
-  const results = await Promise.all(requests);
-  const errors = results.map((result) => result.error).filter(Boolean);
-  if (errors.length > 0) throw errors[0];
-
+  const trimmed = query.trim();
   const courses = new Map<string, CourseHit>();
-  for (const result of results) {
-    for (const course of (result.data ?? []) as CourseRow[]) {
+  const collect = (rows: unknown) => {
+    for (const course of (rows ?? []) as CourseRow[]) {
       courses.set(course.raw_id, getCourseHit(course));
     }
+  };
+
+  if (!trimmed) {
+    const { data, error } = await createCourseQuery(c);
+    if (error) throw error;
+    collect(data);
+    return [...courses.values()];
   }
+
+  const { data, error } = await loadCoursesByRpc(c, trimmed);
+  if (!error) {
+    collect(data);
+    return [...courses.values()];
+  }
+
+  // Keep search answering even if the function is unavailable or rejects a
+  // query: degrade to the scalar `ilike` match rather than failing outright.
+  // Teacher matches are lost on this path, which is why it is not the default.
+  console.error("search_courses RPC failed, using ilike fallback:", {
+    message: error.message,
+    code: error.code,
+  });
+  const scalar = await createCourseQuery(c, trimmed);
+  if (scalar.error) throw scalar.error;
+  collect(scalar.data);
   return [...courses.values()];
 };
 

--- a/services/secure-api/Dockerfile
+++ b/services/secure-api/Dockerfile
@@ -22,6 +22,7 @@ COPY apps/web/package.json ./apps/web/package.json
 COPY tools/build-scripts/package.json ./tools/build-scripts/package.json
 COPY tools/data-sync/package.json ./tools/data-sync/package.json
 COPY tools/dict-manager/package.json ./tools/dict-manager/package.json
+COPY tools/map-data/package.json ./tools/map-data/package.json
 
 # Install dependencies
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
Follow-up to #849. Search works there, but it was slow and teacher search was wrong.

## Search matched in the wrong place

Fallback search matched with PostgREST `ilike` across five scalar columns, then ran a **second unfiltered query for up to 10,000 full rows on every keystroke**, purely to find teacher matches — PostgREST cannot apply `ilike` to the `text[]` teacher columns.

The `courses` table already has PGroonga indexes on the name and teacher columns, and the database already exposes `search_courses(keyword)` built on them. This calls that instead. PGroonga tokenizes CJK correctly and covers the array columns, so the scan is gone.

Measured against production, same machine, same queries:

| query | before | after |
|---|---|---|
| `thermodynamics` | 2417ms, 128 hits | 1322ms, 128 hits |
| `IBP 105100` | 1473ms, 1 hit | **272ms**, 1 hit |
| `吳貞興` (teacher) | 1951ms, **1 hit** | **267ms, 8 hits** |

Teacher search was not merely slow, it was **wrong**: the bounded scan only saw whichever rows happened to sort first, so it reported one match where there are eight.

If the function is unavailable or rejects a query, search degrades to the previous scalar `ilike` path rather than failing — teacher matches are lost on that path, which is why it is not the default.

**No schema change and no generated-type change.** The function and its types already existed; this only changes which one the Worker calls.

## secure-api image build has been broken on main

Unrelated to #849, but it blocks the cross-device sync fix from reaching production:

```
error: lockfile had changes, but lockfile is frozen
process "/bin/sh -c bun install --frozen-lockfile" exit code 1
```

`tools/map-data` is a workspace under the root `workspaces: ["tools/*"]` but was never added to the secure-api Dockerfile's list of copied `package.json` files. bun therefore saw a missing workspace and refused the frozen lockfile. It has been failing since `d47f51fd`, which introduced that package.

Reproduced by staging exactly the Dockerfile's file list and removing only `tools/map-data/package.json` — that reproduces the CI error verbatim, and restoring it makes `bun install --frozen-lockfile` succeed.

`apps/web/Dockerfile` has the same latent problem (it copies no `tools/*` packages at all), but its CI job is commented out, so it is left alone rather than speculatively changed.

## Verification

- `bunx tsc --noEmit` in `services/api` — clean.
- Local Worker against production Supabase — table above.
- Dockerfile deps stage simulated locally with `--frozen-lockfile`: fails without the fix, succeeds with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYBuoNDX26Jd2gvxmc8sTb
