### PR TITLE
fix(web): let asset revalidation through instead of 404ing it

### DIFF
--- a/apps/web/worker.ts
+++ b/apps/web/worker.ts
@@ -33,7 +33,11 @@ async function fetchStaticAsset(request: Request, env: Env): Promise<Response> {
       .trim()
       .toLowerCase();
 
-    if (!response.ok || contentType === "text/html") {
+    // Only a genuine miss, or the SPA fallback serving index.html in place of
+    // an asset, should 404 here. Anything below 400 must pass through
+    // untouched -- in particular 304, which is what every browser reload of a
+    // cached asset receives after revalidating with If-None-Match.
+    if (response.status >= 400 || contentType === "text/html") {
       return missingAssetResponse();
     }
 


### PR DESCRIPTION
**Regression I introduced in #849. Production breaks on reload.**

The static asset guard rejected any response that was not `ok`. `Response.ok` is false for **304 Not Modified**. Every browser reload of an already-cached asset revalidates with `If-None-Match`, the assets binding answers 304, and the guard turned that into a 404:

```
HTTP 404 https://nthumods.com/assets/index-DIA7zTdp.js
HTTP 404 https://nthumods.com/assets/index-W9zueHuH.css
HTTP 404 https://nthumods.com/registerSW.js
```

The entry chunk and stylesheet fail to load and the page renders blank — the exact symptom the guard was added to remove.

A plain first request is unaffected, which is why a cold check passes. Only a repeat visit or reload triggers it. Against production right now:

```
plain GET      -> 200, etag W/"339fbafd..."
If-None-Match  -> 404 text/plain     <- should be 304
```

## Fix

Pass anything below 400 through untouched; 404 only on a genuine miss or on the SPA fallback serving `index.html` in place of an asset.

## Verification

Against a local build of the Worker:

| request | result |
|---|---|
| plain GET | 200 `text/javascript` |
| `If-None-Match` | **304** |
| missing asset | 404 `text/plain` |
| deep link `/en/timetable` | 200 `text/html` |
| `registerSW.js` | 200 `text/javascript` |

And with a real browser doing load → service worker install → reload:

- before: `VISIT 2 body len: 0` (blank), three 404s
- after: `VISIT 2 body len: 520`, page renders, no 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYBuoNDX26Jd2gvxmc8sTb
