### PR TITLE
test: run every test file instead of a fixed path per workspace

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "bun test src/features/campusMap",
+    "test": "bun test src",
     "preview": "vite preview",
     "lint": "eslint src --fix",
     "type-check": "tsc --noEmit",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
-    "test": "bun test src/campus",
+    "test": "bun test src",
     "lint": "eslint src --ext .ts,.tsx --fix",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -18,7 +18,7 @@
     "build": "bun run prisma:generate && tsc --outDir dist --skipLibCheck --noEmitOnError false --allowJs --noImplicitReturns false --noUnusedLocals false --noUnusedParameters false",
     "clean": "rm -rf dist",
     "lint": "echo 'API lint check'",
-    "test": "echo 'API tests'"
+    "test": "bun test src"
   },
   "dependencies": {
     "@algolia/requester-fetch": "^4.23.3",


### PR DESCRIPTION
Closes #851 (test-script part).

Three workspaces scoped their test script to a path. At time of writing:

| Workspace | Script | Tests run |
| --- | --- | --: |
| `services/api` | `echo 'API tests'` | 0 → 96 |
| `apps/web` | `bun test src/features/campusMap` | 9 → 65 |
| `packages/shared` | `bun test src/campus` | 11 → 11 |
| `services/secure-api` | `bun test src` (unchanged) | 48 |

`services/api` has never run a test. Its three suites — `mcp-server`, `timetable-ics` and `deepCompare` — have been present and passing the whole time.

`apps/web` ran only the campusMap feature, so a test added anywhere else was collected by no script. #849 added `src/hooks/syncedStorage.test.ts` and it was never executed.

`packages/shared` is unchanged in count because `src/campus` already held every test file it has. Widening it keeps a future one from being missed the same way. `services/secure-api` was never scoped and is untouched.

## Verification

All 220 pass, so this cannot turn CI red:

```
$ bun run test
@courseweb/api          96 pass  0 fail
@courseweb/web          65 pass  0 fail
@courseweb/secure-api   48 pass  0 fail
@courseweb/shared       11 pass  0 fail
 Tasks:    11 successful, 11 total
```

`bun run build` also passes, 11/11.

`bun test src` does not collect the six `*.test.d.ts` files under `apps/web/src/types` — bun does not treat generated declaration files as tests.

## Deliberately not included

The `mcp-server.test.ts` rewrite. Those 8 tests assert against a ~216-line inline copy of the tool definitions rather than importing the module, so they cannot fail in response to a change in it. Keeping that separate, as suggested on #851, so this stays reviewable.

## Notes

#851 says "64/160". Both numbers are superseded. 64 was correct when filed and has since moved to 68 as other workspaces gained tests. 160 was wrong when written — it counted only the `services/api` gain and missed that widening `apps/web` adds 56 more. The correct figure is 68 → 220 as measured above, and it will keep drifting as tests are added.


I have verified claude's work by running `bun run test`  in `apps/web`, `services/api` and `packages/shared` directories myself, and the numbers are consistent. I also ran `bun run build` and it did pass.