### PR TITLE
docs(secure-api): JWKS is serving again

### DIFF
--- a/services/secure-api/docs/chumei-integration.md
+++ b/services/secure-api/docs/chumei-integration.md
@@ -236,11 +236,10 @@ export const userManager = new UserManager({
 
 PKCE is on by default in that library. Do not configure a `client_secret`.
 
-## Known issue
+## Status
 
-`https://auth.nthumods.com/.well-known/jwks.json` currently returns
-`500 Internal Server Error`, which breaks discovery-driven `id_token`
-verification. The cause is the deployed environment, not the protocol flow — the
-`JWT_PUBLIC_KEY` environment variable is missing or malformed on the production
-host. Until it is fixed, either validate tokens through `/introspect`, or pin the
-public key locally.
+All endpoints on this page are live and verified against
+`https://auth.nthumods.com`, including `/.well-known/jwks.json`, which returns
+the RS256 key with `kid` `"1"`. Verify `id_token`s against it through the
+discovery document; reach for `/introspect` only when you need to know an access
+token has not been revoked since issue.


### PR DESCRIPTION
The integration guide told third parties that /.well-known/jwks.json was returning 500 and to work around it. It has been serving since #868 was deployed, verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvM2uNLLbgPyrp1HEHobtb