### PR TITLE
fix(api): stop reporting auth, bus and calendar failures as opaque 500s

### DIFF
--- a/services/api/src/aca-calendar.ts
+++ b/services/api/src/aca-calendar.ts
@@ -52,7 +52,12 @@ const app = new Hono()
         // Google reports a revoked, deleted or API-disabled key as a 400
         // API_KEY_INVALID. Surface that as a distinct upstream failure so it is
         // not mistaken for a bug in this handler.
-        const detail = await res.text();
+        // The upstream error body echoes back the caller's own query
+        // parameters, so strip control characters and cap the length before
+        // logging it — otherwise a crafted `start`/`end` could forge log lines.
+        const detail = (await res.text())
+          .replace(/[\u0000-\u001F\u007F]+/g, " ")
+          .slice(0, 500);
         console.error(
           `Google Calendar request failed (${res.status}): ${detail}`,
         );

--- a/services/api/src/aca-calendar.ts
+++ b/services/api/src/aca-calendar.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 import { env } from "hono/adapter";
+import { HTTPException } from "hono/http-exception";
 
 export type CalendarApiResponse = {
   kind: string;
@@ -37,18 +38,39 @@ const app = new Hono()
     async (c) => {
       const { start, end } = c.req.valid("query");
       const { CALENDAR_API_KEY } = env<{ CALENDAR_API_KEY: string }>(c);
+
+      if (!CALENDAR_API_KEY) {
+        console.error("CALENDAR_API_KEY is not configured");
+        throw new HTTPException(503, {
+          message: "Academic calendar is not configured",
+        });
+      }
+
       const CALENDAR_API_URL = `https://www.googleapis.com/calendar/v3/calendars/nthu.acad%40gmail.com/events?key=${CALENDAR_API_KEY}&timeMin=${start.toISOString().slice(0, 10)}T00:00:00Z&timeMax=${end.toISOString().slice(0, 10)}T00:00:00Z`;
       const res = await fetch(CALENDAR_API_URL);
       if (!res.ok) {
-        throw new Error(
-          "Failed to fetch data " + res.status + (await res.text()),
+        // Google reports a revoked, deleted or API-disabled key as a 400
+        // API_KEY_INVALID. Surface that as a distinct upstream failure so it is
+        // not mistaken for a bug in this handler.
+        const detail = await res.text();
+        console.error(
+          `Google Calendar request failed (${res.status}): ${detail}`,
         );
+        throw new HTTPException(502, {
+          message:
+            res.status === 400 || res.status === 403
+              ? "Academic calendar upstream rejected the API key"
+              : "Academic calendar upstream is unavailable",
+        });
       }
-      const resJson = (await res.json()) as any;
-      if (resJson.success === false) {
-        throw new Error("Failed to fetch data " + resJson.result);
+      const resJson = (await res.json()) as { items?: CalendarApiResponse[] };
+      if (!Array.isArray(resJson.items)) {
+        console.error("Google Calendar response had no items array");
+        throw new HTTPException(502, {
+          message: "Academic calendar upstream returned an unexpected payload",
+        });
       }
-      const calendarDatas = resJson.items as CalendarApiResponse[];
+      const calendarDatas = resJson.items;
 
       return c.json(
         calendarDatas.map((item) => {

--- a/services/api/src/bus.ts
+++ b/services/api/src/bus.ts
@@ -141,187 +141,199 @@ interface CompleteBusData {
   };
 }
 
+/**
+ * Builds the complete bus dataset from the NTHU affairs pages.
+ *
+ * Kept as a plain function rather than an HTTP call so that `/schedules` can
+ * reuse it directly. Fetching this Worker's own public hostname made the
+ * subrequest loop back through the `api.nthumods.com` custom domain, which
+ * Cloudflare rejects with an immediate 522.
+ */
+async function fetchCompleteBusData(): Promise<CompleteBusData> {
+  // Fetch both campus and inter-campus data
+  const url1 =
+    "https://affairs.site.nthu.edu.tw/p/412-1165-20978.php?Lang=zh-tw"; // campus bus (red/green)
+  const url2 =
+    "https://affairs.site.nthu.edu.tw/p/412-1165-20979.php?Lang=zh-tw"; // inter-campus (route1/route2)
+
+  const [response1, response2] = await Promise.all([
+    fetch(url1),
+    fetch(url2),
+  ]);
+
+  let busData: ParsedBusData = {};
+
+  // Parse campus bus data
+  if (response1.ok) {
+    const html1 = await response1.text();
+    const { document: doc1 } = parseHTML(html1);
+    const scripts1 = doc1.querySelectorAll("script");
+
+    for (let i = 0; i < scripts1.length; i++) {
+      const script = scripts1[i];
+      const scriptContent = script.textContent || script.innerHTML;
+
+      if (
+        scriptContent.includes("towardTSMCBuildingInfo") ||
+        scriptContent.includes("weekdayBusScheduleTowardTSMCBuilding")
+      ) {
+        const campusData = extractBusDataFromScript(scriptContent);
+        busData = { ...busData, ...campusData };
+        break;
+      }
+    }
+  }
+
+  // Parse inter-campus bus data
+  if (response2.ok) {
+    const html2 = await response2.text();
+    const { document: doc2 } = parseHTML(html2);
+    const scripts2 = doc2.querySelectorAll("script");
+
+    for (let i = 0; i < scripts2.length; i++) {
+      const script = scripts2[i];
+      const scriptContent = script.textContent || script.innerHTML;
+
+      if (
+        scriptContent.includes("towardNandaInfo") ||
+        scriptContent.includes("weekdayBusScheduleTowardNanda")
+      ) {
+        const intercampusData = extractBusDataFromScript(scriptContent);
+        busData = { ...busData, ...intercampusData };
+        break;
+      }
+    }
+  }
+
+  if (Object.keys(busData).length === 0) {
+    throw new Error("Bus schedule data not found in either page");
+  }
+
+  // Transform the data into the organized structure
+  const transformIntercampusBuses = (
+    buses: Array<{ time: string; line: string; description: string }>,
+  ) => {
+    return buses.map((item) => {
+      // Determine type based on line or description
+      let type: "route1" | "route2" | undefined = undefined;
+      if (
+        item.line === "route1" ||
+        item.description.includes("路線一") ||
+        item.description.includes("Route I")
+      ) {
+        type = "route1";
+      } else if (
+        item.line === "route2" ||
+        item.description.includes("路線二") ||
+        item.description.includes("Route II")
+      ) {
+        type = "route2";
+      }
+
+      return {
+        time: item.time,
+        description: item.description,
+        route: "南大區間車" as const,
+        type,
+      };
+    });
+  };
+
+  const transformCampusBuses = (
+    buses: Array<{
+      time: string;
+      depStop: string;
+      line: string;
+      description: string;
+    }>,
+  ) => {
+    return buses.map((item) => ({
+      time: item.time,
+      description: item.description,
+      route: "校園公車" as const,
+      dep_stop: item.depStop,
+      line: item.line,
+    }));
+  };
+
+  const result: CompleteBusData = {
+    main: {
+      toward_TSMC_building_info: busData.towardTSMCBuildingInfo || {
+        direction: "往台積館",
+        duration: "約15分鐘",
+        route: "紅線、綠線",
+        routeEN: "Red Line, Green Line",
+      },
+      toward_main_gate_info: busData.towardMainGateInfo || {
+        direction: "往北校門口",
+        duration: "約15分鐘",
+        route: "紅線、綠線",
+        routeEN: "Red Line, Green Line",
+      },
+      weekday: {
+        toward_TSMC_building: transformCampusBuses(
+          busData.weekdayBusScheduleTowardTSMCBuilding || [],
+        ),
+        toward_main_gate: transformCampusBuses(
+          busData.weekdayBusScheduleTowardMainGate || [],
+        ),
+      },
+      weekend: {
+        toward_TSMC_building: transformCampusBuses(
+          busData.weekendBusScheduleTowardTSMCBuilding ||
+            busData.weekdayBusScheduleTowardTSMCBuilding ||
+            [],
+        ),
+        toward_main_gate: transformCampusBuses(
+          busData.weekendBusScheduleTowardMainGate ||
+            busData.weekdayBusScheduleTowardMainGate ||
+            [],
+        ),
+      },
+    },
+    nanda: {
+      toward_south_campus_info: busData.towardNandaInfo || {
+        direction: "往南大校區",
+        duration: "約20分鐘",
+        route: "南大區間車",
+        routeEN: "Nanda Shuttle",
+      },
+      toward_main_campus_info: busData.towardMainCampusInfo || {
+        direction: "往校本部",
+        duration: "約20分鐘",
+        route: "南大區間車",
+        routeEN: "Nanda Shuttle",
+      },
+      weekday: {
+        toward_south_campus: transformIntercampusBuses(
+          busData.weekdayBusScheduleTowardNanda || [],
+        ),
+        toward_main_campus: transformIntercampusBuses(
+          busData.weekdayBusScheduleTowardMainCampus || [],
+        ),
+      },
+      weekend: {
+        toward_south_campus: transformIntercampusBuses(
+          busData.weekendBusScheduleTowardNanda ||
+            busData.weekdayBusScheduleTowardNanda ||
+            [],
+        ),
+        toward_main_campus: transformIntercampusBuses(
+          busData.weekendBusScheduleTowardMainCampus ||
+            busData.weekdayBusScheduleTowardMainCampus ||
+            [],
+        ),
+      },
+    },
+  };
+
+  return result;
+}
+
 const app = new Hono()
   .get("/", async (c) => {
     try {
-      // Fetch both campus and inter-campus data
-      const url1 =
-        "https://affairs.site.nthu.edu.tw/p/412-1165-20978.php?Lang=zh-tw"; // campus bus (red/green)
-      const url2 =
-        "https://affairs.site.nthu.edu.tw/p/412-1165-20979.php?Lang=zh-tw"; // inter-campus (route1/route2)
-
-      const [response1, response2] = await Promise.all([
-        fetch(url1),
-        fetch(url2),
-      ]);
-
-      let busData: ParsedBusData = {};
-
-      // Parse campus bus data
-      if (response1.ok) {
-        const html1 = await response1.text();
-        const { document: doc1 } = parseHTML(html1);
-        const scripts1 = doc1.querySelectorAll("script");
-
-        for (let i = 0; i < scripts1.length; i++) {
-          const script = scripts1[i];
-          const scriptContent = script.textContent || script.innerHTML;
-
-          if (
-            scriptContent.includes("towardTSMCBuildingInfo") ||
-            scriptContent.includes("weekdayBusScheduleTowardTSMCBuilding")
-          ) {
-            const campusData = extractBusDataFromScript(scriptContent);
-            busData = { ...busData, ...campusData };
-            break;
-          }
-        }
-      }
-
-      // Parse inter-campus bus data
-      if (response2.ok) {
-        const html2 = await response2.text();
-        const { document: doc2 } = parseHTML(html2);
-        const scripts2 = doc2.querySelectorAll("script");
-
-        for (let i = 0; i < scripts2.length; i++) {
-          const script = scripts2[i];
-          const scriptContent = script.textContent || script.innerHTML;
-
-          if (
-            scriptContent.includes("towardNandaInfo") ||
-            scriptContent.includes("weekdayBusScheduleTowardNanda")
-          ) {
-            const intercampusData = extractBusDataFromScript(scriptContent);
-            busData = { ...busData, ...intercampusData };
-            break;
-          }
-        }
-      }
-
-      if (Object.keys(busData).length === 0) {
-        throw new Error("Bus schedule data not found in either page");
-      }
-
-      // Transform the data into the organized structure
-      const transformIntercampusBuses = (
-        buses: Array<{ time: string; line: string; description: string }>,
-      ) => {
-        return buses.map((item) => {
-          // Determine type based on line or description
-          let type: "route1" | "route2" | undefined = undefined;
-          if (
-            item.line === "route1" ||
-            item.description.includes("路線一") ||
-            item.description.includes("Route I")
-          ) {
-            type = "route1";
-          } else if (
-            item.line === "route2" ||
-            item.description.includes("路線二") ||
-            item.description.includes("Route II")
-          ) {
-            type = "route2";
-          }
-
-          return {
-            time: item.time,
-            description: item.description,
-            route: "南大區間車" as const,
-            type,
-          };
-        });
-      };
-
-      const transformCampusBuses = (
-        buses: Array<{
-          time: string;
-          depStop: string;
-          line: string;
-          description: string;
-        }>,
-      ) => {
-        return buses.map((item) => ({
-          time: item.time,
-          description: item.description,
-          route: "校園公車" as const,
-          dep_stop: item.depStop,
-          line: item.line,
-        }));
-      };
-
-      const result: CompleteBusData = {
-        main: {
-          toward_TSMC_building_info: busData.towardTSMCBuildingInfo || {
-            direction: "往台積館",
-            duration: "約15分鐘",
-            route: "紅線、綠線",
-            routeEN: "Red Line, Green Line",
-          },
-          toward_main_gate_info: busData.towardMainGateInfo || {
-            direction: "往北校門口",
-            duration: "約15分鐘",
-            route: "紅線、綠線",
-            routeEN: "Red Line, Green Line",
-          },
-          weekday: {
-            toward_TSMC_building: transformCampusBuses(
-              busData.weekdayBusScheduleTowardTSMCBuilding || [],
-            ),
-            toward_main_gate: transformCampusBuses(
-              busData.weekdayBusScheduleTowardMainGate || [],
-            ),
-          },
-          weekend: {
-            toward_TSMC_building: transformCampusBuses(
-              busData.weekendBusScheduleTowardTSMCBuilding ||
-                busData.weekdayBusScheduleTowardTSMCBuilding ||
-                [],
-            ),
-            toward_main_gate: transformCampusBuses(
-              busData.weekendBusScheduleTowardMainGate ||
-                busData.weekdayBusScheduleTowardMainGate ||
-                [],
-            ),
-          },
-        },
-        nanda: {
-          toward_south_campus_info: busData.towardNandaInfo || {
-            direction: "往南大校區",
-            duration: "約20分鐘",
-            route: "南大區間車",
-            routeEN: "Nanda Shuttle",
-          },
-          toward_main_campus_info: busData.towardMainCampusInfo || {
-            direction: "往校本部",
-            duration: "約20分鐘",
-            route: "南大區間車",
-            routeEN: "Nanda Shuttle",
-          },
-          weekday: {
-            toward_south_campus: transformIntercampusBuses(
-              busData.weekdayBusScheduleTowardNanda || [],
-            ),
-            toward_main_campus: transformIntercampusBuses(
-              busData.weekdayBusScheduleTowardMainCampus || [],
-            ),
-          },
-          weekend: {
-            toward_south_campus: transformIntercampusBuses(
-              busData.weekendBusScheduleTowardNanda ||
-                busData.weekdayBusScheduleTowardNanda ||
-                [],
-            ),
-            toward_main_campus: transformIntercampusBuses(
-              busData.weekendBusScheduleTowardMainCampus ||
-                busData.weekdayBusScheduleTowardMainCampus ||
-                [],
-            ),
-          },
-        },
-      };
-
-      return c.json(result);
+      return c.json(await fetchCompleteBusData());
     } catch (error) {
       console.error("Error fetching bus schedule:", error);
       return c.json({ error: "Failed to fetch bus schedule data" }, 500);
@@ -343,15 +355,7 @@ const app = new Hono()
       const { bus_type, day, direction } = c.req.valid("query");
 
       try {
-        // Get complete data from main endpoint
-        const completeDataResponse = await fetch(
-          `${c.req.url.replace("/schedules", "")}`,
-        );
-        const completeData: CompleteBusData = await completeDataResponse.json();
-
-        if (!completeDataResponse.ok) {
-          throw new Error("Failed to fetch complete bus data");
-        }
+        const completeData = await fetchCompleteBusData();
 
         // Determine which schedule to return based on parameters
         const currentDay =
@@ -399,10 +403,12 @@ const app = new Hono()
                 : completeData.nanda.weekday.toward_south_campus;
 
             for (const item of intercampusSchedule) {
+              // "nanda" means every inter-campus bus. Upstream now tags each
+              // entry route1 or route2, so filtering it to untyped entries
+              // matched nothing at all.
               if (
                 (bus_type === "route1" && item.type !== "route1") ||
-                (bus_type === "route2" && item.type !== "route2") ||
-                (bus_type === "nanda" && item.type !== undefined)
+                (bus_type === "route2" && item.type !== "route2")
               ) {
                 continue;
               }
@@ -448,10 +454,12 @@ const app = new Hono()
                 : completeData.nanda.weekday.toward_main_campus;
 
             for (const item of intercampusSchedule) {
+              // "nanda" means every inter-campus bus. Upstream now tags each
+              // entry route1 or route2, so filtering it to untyped entries
+              // matched nothing at all.
               if (
                 (bus_type === "route1" && item.type !== "route1") ||
-                (bus_type === "route2" && item.type !== "route2") ||
-                (bus_type === "nanda" && item.type !== undefined)
+                (bus_type === "route2" && item.type !== "route2")
               ) {
                 continue;
               }

--- a/services/api/src/utils/auth.test.ts
+++ b/services/api/src/utils/auth.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { auth } from "./auth";
+
+// Under Bun, hono/adapter's env() reads process.env; only workerd reads c.env.
+const ENV = {
+  NTHUMODS_AUTH_INTROSPECTION_URL: "https://auth.example.com/introspect",
+  NTHUMODS_AUTH_CLIENT_ID: "client",
+  NTHUMODS_AUTH_CLIENT_SECRET: "secret",
+};
+
+const realFetch = globalThis.fetch;
+const realEnv = { ...process.env };
+
+beforeEach(() => {
+  Object.assign(process.env, ENV);
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  for (const key of Object.keys(ENV)) {
+    if (key in realEnv) process.env[key] = realEnv[key];
+    else delete process.env[key];
+  }
+});
+
+/** Stubs the token introspection endpoint with a fixed response. */
+const stubIntrospection = (response: Response) => {
+  globalThis.fetch = mock(async () => response) as unknown as typeof fetch;
+};
+
+const activeToken = (scope: string) =>
+  new Response(JSON.stringify({ active: true, username: "u1", scope }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const buildApp = (scopes?: string[], handler?: () => never) =>
+  new Hono().get("/protected", auth(scopes), (c) =>
+    handler ? handler() : c.json({ ok: true }),
+  );
+
+const call = (app: Hono, headers: Record<string, string> = {}) =>
+  app.request("/protected", { headers });
+
+describe("auth middleware status codes", () => {
+  it("returns 401, not 500, when the Authorization header is missing", async () => {
+    const res = await call(buildApp());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401, not 500, when the scheme is not Bearer", async () => {
+    const res = await call(buildApp(), { Authorization: "Basic abc" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401, not 500, when introspection rejects the token", async () => {
+    stubIntrospection(new Response("nope", { status: 401 }));
+    const res = await call(buildApp(), { Authorization: "Bearer bad" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401, not 500, when the token is inactive", async () => {
+    stubIntrospection(
+      new Response(JSON.stringify({ active: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const res = await call(buildApp(), { Authorization: "Bearer expired" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403, not 500, when the token lacks the required scope", async () => {
+    stubIntrospection(activeToken("profile"));
+    const res = await call(buildApp(["calendar"]), {
+      Authorization: "Bearer ok",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a token whose scope matches", async () => {
+    stubIntrospection(activeToken("calendar"));
+    const res = await call(buildApp(["calendar"]), {
+      Authorization: "Bearer ok",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a base scope for a namespaced requirement", async () => {
+    stubIntrospection(activeToken("user"));
+    const res = await call(buildApp(["user:read"]), {
+      Authorization: "Bearer ok",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when introspection itself fails unexpectedly", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const res = await call(buildApp(), { Authorization: "Bearer ok" });
+    expect(res.status).toBe(500);
+  });
+
+  it("does not rewrite a downstream handler's status as an auth failure", async () => {
+    stubIntrospection(activeToken("calendar"));
+    const app = buildApp(["calendar"], () => {
+      throw new HTTPException(404, { message: "Not Found" });
+    });
+    const res = await call(app, { Authorization: "Bearer ok" });
+    expect(res.status).toBe(404);
+  });
+});

--- a/services/api/src/utils/auth.ts
+++ b/services/api/src/utils/auth.ts
@@ -35,6 +35,8 @@ export const auth = (requiredScopes?: string[]): MiddlewareHandler => {
 
     const token = authHeader.substring(7); // Remove "Bearer " prefix
 
+    let user: User;
+
     try {
       const {
         NTHUMODS_AUTH_INTROSPECTION_URL,
@@ -87,25 +89,30 @@ export const auth = (requiredScopes?: string[]): MiddlewareHandler => {
       }
 
       // Create user object
-      const userScopes = introspection.scope?.split(" ") || [];
-      const user: User = {
+      user = {
         sub: introspection.username,
-        scopes: userScopes,
+        scopes: introspection.scope?.split(" ") || [],
       };
-
-      // If no scopes are required, just set the user info and proceed
-      if (!requiredScopes || requiredScopes.length === 0) {
-        c.set("user", user);
-        await next();
-        return;
+    } catch (error) {
+      // An HTTPException here is a deliberate 401/403/500 raised above, and
+      // already carries the status the caller should see. Only an unexpected
+      // failure (the introspection request itself) becomes a 500.
+      if (error instanceof HTTPException) {
+        throw error;
       }
+      console.error("Authentication error:", error);
+      throw new HTTPException(500, {
+        message: "Internal Server Error",
+      });
+    }
 
-      // Check if the user has the required scopes
+    // Check if the user has the required scopes
+    if (requiredScopes && requiredScopes.length > 0) {
       const hasRequiredScope = requiredScopes.some((requiredScope) => {
         // Handle patterns like "user:read" where "user" scope is sufficient
         const [baseScope] = requiredScope.split(":");
         return (
-          userScopes.includes(requiredScope) || userScopes.includes(baseScope)
+          user.scopes.includes(requiredScope) || user.scopes.includes(baseScope)
         );
       });
 
@@ -114,17 +121,14 @@ export const auth = (requiredScopes?: string[]): MiddlewareHandler => {
           message: "Forbidden",
         });
       }
-
-      // Set user information in the context for downstream handlers
-      c.set("user", user);
-
-      await next();
-    } catch (error) {
-      console.error("Authentication error:", error);
-      throw new HTTPException(500, {
-        message: "Internal Server Error",
-      });
     }
+
+    // Set user information in the context for downstream handlers
+    c.set("user", user);
+
+    // Deliberately outside the try above: a route handler's own failure is not
+    // an authentication error and must not be rewritten as one.
+    await next();
   };
 };
 


### PR DESCRIPTION
Four bugs behind the 500s on `api.nthumods.com`. All diagnosed from `wrangler tail` against the live worker, then fixed and verified locally against `wrangler dev`.

## 1. Every auth failure was a 500 (`utils/auth.ts`)

`auth()` wrapped the whole middleware in one `try`/`catch` that rewrote **every** error as a 500 — including the deliberate `HTTPException(401)` and `HTTPException(403)` thrown a few lines above it. Live log from real user traffic:

```
<-- GET /timetable-share/groups
Authentication error: Error: Unauthorized
--> GET /timetable-share/groups 500 104ms
```

`await next()` sat inside the same `try`, so a **route handler's own failure** was also caught, logged as "Authentication error" and returned as 500 — masking every downstream error on authenticated routes.

Fixed: re-throw `HTTPException` untouched; move the scope check and `next()` out of the `try` so only the introspection request itself can produce a 500.

## 2. `/bus/schedules` fetched the worker's own hostname (`bus.ts`)

```ts
const completeDataResponse = await fetch(`${c.req.url.replace("/schedules", "")}`);
const completeData: CompleteBusData = await completeDataResponse.json();
if (!completeDataResponse.ok) { throw new Error("Failed to fetch complete bus data"); }
```

That resolves to `https://api.nthumods.com/bus` — the worker's own custom domain (`wrangler.toml:7`). Cloudflare rejects the same-zone loopback with `error code: 522` in **16ms**, far too fast for a real connection timeout. `/bus` and the NTHU upstream both return 200 when called from outside; only the self-fetch path failed.

```
Error fetching filtered bus schedule: SyntaxError: Unexpected token 'e', "error code: 522\n" is not valid JSON
```

Note `.json()` ran **before** the `.ok` check, so the HTML error body threw `SyntaxError` instead of the intended error. Fixed by extracting the dataset builder into `fetchCompleteBusData()` and calling it directly — no subrequest at all.

## 3. `bus_type=nanda` returned 0 items, always (`bus.ts`)

Found while verifying #2. The filter skipped any entry with a defined `type`:

```ts
(bus_type === "nanda" && item.type !== undefined)
```

But upstream now tags every inter-campus bus `route1` or `route2`, so nothing ever matched — `nanda` returned an empty array for every day and direction. Against live upstream data:

| query | before | after |
|---|---|---|
| `nanda&weekday&down` | 0 | 48 |
| `nanda&weekday&up` | 0 | 48 |
| `nanda&weekend&down` | 0 | 4 |

48 = 37 `route1` + 11 `route2`, which matches `route1`/`route2` queried separately. `all` (179), `red` (69), `route1` (37), `route2` (11) are unchanged.

## 4. `/acacalendar` hid a dead API key behind a generic 500 (`aca-calendar.ts`)

```
Error: Failed to fetch data 400{ "error": { "code": 400,
  "message": "API key not valid. Please pass a valid API key.",
  "reason": "API_KEY_INVALID", "service": "calendar-json.googleapis.com" }}
```

`CALENDAR_API_KEY` **is** set as a worker secret — Google rejects the value. The same value in `services/api/.dev.vars` fails identically when called against Google directly, so the key was revoked/deleted or the Calendar API was disabled on that GCP project.

This is an upstream credential problem, not a handler bug, so it now reports 502 naming the cause (503 if the key is absent entirely) and logs the upstream body.

> ⚠️ **The key still needs regenerating** — this change only makes the failure legible. Once a new key exists it goes in both `wrangler secret put CALENDAR_API_KEY` and `services/api/.dev.vars`.

## On the 503 that started this

Not reproducible and not from this code — nothing in `services/api` returns 503. Last API deploy was `2026-09-11T07:21Z`, ~10 hours before I hit it, so it wasn't a deploy window. A Cloudflare edge blip that happened to mask the real failures above.

## Verification

- `services/api` tests: **105 pass, 0 fail** (was 96 — adds 9).
- `tsc --noEmit --skipLibCheck` on `services/api`: **0 errors**.
- Against local `wrangler dev`:

| | before | after |
|---|---|---|
| `/bus/schedules` | 500 | **200**, real data |
| `/acacalendar` (bad key) | 500 `Internal Server Error` | **502** `Academic calendar upstream rejected the API key` |
| no `Authorization` header | 500 | **401** |
| non-Bearer scheme | 500 | **401** |
| bogus bearer token | 500 | **401** |

New `services/api/src/utils/auth.test.ts` covers all the regressed status codes, including that a downstream handler's 404 is no longer rewritten as a 500.

Not covered by a test: the bus parsing path, which would need HTML fixtures of the two NTHU affairs pages. The nanda fix was verified against live upstream data instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvM2uNLLbgPyrp1HEHobtb