### PR TITLE
feat(admin): admin center for stats, users, announcements and OAuth clients

### DIFF
--- a/apps/web/src/app/[lang]/admin/announcements/page.tsx
+++ b/apps/web/src/app/[lang]/admin/announcements/page.tsx
@@ -128,6 +128,22 @@ const emptyForm = (): AnnouncementForm => {
   };
 };
 
+/**
+ * Live rows predate the three-value severity the API now enforces — the 2023
+ * typhoon notice is stored as `danger`, which the server's schema rejects.
+ * Reading one has to keep working, so an unrecognised value is mapped to the
+ * closest supported one rather than seeding the form with something that only
+ * fails on save, or indexing the style maps below with a key they do not have.
+ */
+const KNOWN_SEVERITIES: AnnouncementSeverity[] = ["info", "warning", "error"];
+
+const normalizeSeverity = (severity: string): AnnouncementSeverity => {
+  if ((KNOWN_SEVERITIES as string[]).includes(severity)) {
+    return severity as AnnouncementSeverity;
+  }
+  return severity === "danger" ? "error" : "info";
+};
+
 const announcementToForm = (
   announcement: AdminAnnouncement,
 ): AnnouncementForm => ({
@@ -138,7 +154,7 @@ const announcementToForm = (
   link_url: announcement.link_url ?? "",
   link_label: announcement.link_label ?? "",
   link_label_en: announcement.link_label_en ?? "",
-  severity: announcement.severity,
+  severity: normalizeSeverity(announcement.severity),
   start_date: toTaipeiInput(announcement.start_date),
   end_date: toTaipeiInput(announcement.end_date),
   active: announcement.active,
@@ -266,7 +282,7 @@ const statusBadgeClasses: Record<AnnouncementStatus, string> = {
 };
 
 const PreviewBanner = ({ form }: { form: AnnouncementForm }) => {
-  const style = severityStyles[form.severity];
+  const style = severityStyles[normalizeSeverity(form.severity)];
   const Icon = style.Icon;
   const title = form.title.trim() || "Announcement title";
   const description = form.description.trim();
@@ -694,7 +710,9 @@ const AdminAnnouncementsPage = () => {
                         <Badge
                           variant="outline"
                           className={
-                            severityBadgeClasses[announcement.severity]
+                            severityBadgeClasses[
+                              normalizeSeverity(announcement.severity)
+                            ]
                           }
                         >
                           {announcement.severity}

--- a/apps/web/src/app/[lang]/admin/announcements/page.tsx
+++ b/apps/web/src/app/[lang]/admin/announcements/page.tsx
@@ -1,5 +1,810 @@
-import { PageHeader } from "../components";
+import { useState, type FormEvent } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Textarea,
+  cn,
+  useToast,
+} from "@courseweb/ui";
+import { AlertTriangle, Info, Pencil, Plus, Trash2, X } from "lucide-react";
+import {
+  EmptyState,
+  ErrorState,
+  InlineSpinner,
+  Mono,
+  PageHeader,
+  formatDateTime,
+} from "../components";
+import {
+  useAdminAnnouncements,
+  useDeleteAnnouncement,
+  useSaveAnnouncement,
+  type AdminAnnouncement,
+  type AdminAnnouncementInput,
+  type AnnouncementSeverity,
+} from "../api";
 
-const AdminAnnouncementsPage = () => <PageHeader title="Announcements" />;
+type AnnouncementForm = {
+  title: string;
+  title_en: string;
+  description: string;
+  description_en: string;
+  link_url: string;
+  link_label: string;
+  link_label_en: string;
+  severity: AnnouncementSeverity;
+  start_date: string;
+  end_date: string;
+  active: boolean;
+  dismissible: boolean;
+  priority: number | "";
+};
+
+type AnnouncementStatus = "Live now" | "Scheduled" | "Expired" | "Draft";
+
+const TAIPEI_TIME_ZONE = "Asia/Taipei";
+const TAIPEI_OFFSET = "+08:00";
+
+const taipeiDateFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: TAIPEI_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+});
+
+// datetime-local has no timezone, so explicitly attach Taipei's +08:00 offset;
+// relying on the browser timezone would make a banner go live eight hours late.
+const toTaipeiInput = (value: Date | string) => {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const parts = taipeiDateFormatter.formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((item) => item.type === type)?.value ?? "";
+
+  return `${part("year")}-${part("month")}-${part("day")}T${part("hour")}:${part("minute")}`;
+};
+
+const toApiDate = (value: string) => {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) return null;
+  const withSeconds = `${value}:00${TAIPEI_OFFSET}`;
+  const date = new Date(withSeconds);
+  return Number.isNaN(date.getTime()) ? null : withSeconds;
+};
+
+const emptyForm = (): AnnouncementForm => {
+  const start = new Date();
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+  return {
+    title: "",
+    title_en: "",
+    description: "",
+    description_en: "",
+    link_url: "",
+    link_label: "",
+    link_label_en: "",
+    severity: "info",
+    start_date: toTaipeiInput(start),
+    end_date: toTaipeiInput(end),
+    active: true,
+    dismissible: true,
+    priority: 0,
+  };
+};
+
+const announcementToForm = (
+  announcement: AdminAnnouncement,
+): AnnouncementForm => ({
+  title: announcement.title,
+  title_en: announcement.title_en ?? "",
+  description: announcement.description ?? "",
+  description_en: announcement.description_en ?? "",
+  link_url: announcement.link_url ?? "",
+  link_label: announcement.link_label ?? "",
+  link_label_en: announcement.link_label_en ?? "",
+  severity: announcement.severity,
+  start_date: toTaipeiInput(announcement.start_date),
+  end_date: toTaipeiInput(announcement.end_date),
+  active: announcement.active,
+  dismissible: announcement.dismissible,
+  priority: announcement.priority,
+});
+
+const isAllowedLink = (link: string) => {
+  if (!link) return true;
+  if (link.startsWith("/")) return true;
+  try {
+    const url = new URL(link);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+const optionalText = (value: string) => value.trim() || null;
+
+const validateForm = (form: AnnouncementForm) => {
+  const title = form.title.trim();
+  if (!title) return "Title is required.";
+  if (title.length > 200) return "Title must be 200 characters or fewer.";
+  if (form.title_en.trim().length > 200) {
+    return "English title must be 200 characters or fewer.";
+  }
+  if (form.description.trim().length > 1000) {
+    return "Description must be 1,000 characters or fewer.";
+  }
+  if (form.description_en.trim().length > 1000) {
+    return "English description must be 1,000 characters or fewer.";
+  }
+  if (form.link_url.trim().length > 500) {
+    return "Link URL must be 500 characters or fewer.";
+  }
+  if (form.link_label.trim().length > 100) {
+    return "Link label must be 100 characters or fewer.";
+  }
+  if (form.link_label_en.trim().length > 100) {
+    return "English link label must be 100 characters or fewer.";
+  }
+
+  const startDate = toApiDate(form.start_date);
+  const endDate = toApiDate(form.end_date);
+  if (!startDate || !endDate) return "Start and end dates are required.";
+  if (new Date(startDate).getTime() >= new Date(endDate).getTime()) {
+    return "End date must be after the start date.";
+  }
+
+  const link = form.link_url.trim();
+  if (!isAllowedLink(link)) return "Enter a valid in-app or web link.";
+
+  if (
+    form.priority === "" ||
+    !Number.isInteger(form.priority) ||
+    form.priority < 0 ||
+    form.priority > 100
+  ) {
+    return "Priority must be a whole number from 0 to 100.";
+  }
+
+  return null;
+};
+
+const formToInput = (form: AnnouncementForm): AdminAnnouncementInput => ({
+  title: form.title.trim(),
+  title_en: optionalText(form.title_en),
+  description: optionalText(form.description),
+  description_en: optionalText(form.description_en),
+  link_url: optionalText(form.link_url),
+  link_label: optionalText(form.link_label),
+  link_label_en: optionalText(form.link_label_en),
+  severity: form.severity,
+  start_date: toApiDate(form.start_date)!,
+  end_date: toApiDate(form.end_date)!,
+  active: form.active,
+  dismissible: form.dismissible,
+  priority: form.priority as number,
+});
+
+const getStatus = (
+  announcement: AdminAnnouncement,
+  now = Date.now(),
+): AnnouncementStatus => {
+  if (!announcement.active) return "Draft";
+
+  const start = new Date(announcement.start_date).getTime();
+  const end = new Date(announcement.end_date).getTime();
+  if (now < start) return "Scheduled";
+  if (now > end) return "Expired";
+  return "Live now";
+};
+
+const severityStyles: Record<
+  AnnouncementSeverity,
+  { className: string; Icon: typeof Info }
+> = {
+  info: {
+    className: "border-border bg-muted text-foreground",
+    Icon: Info,
+  },
+  warning: {
+    className: "border-border bg-accent text-accent-foreground",
+    Icon: AlertTriangle,
+  },
+  error: {
+    className:
+      "border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive",
+    Icon: AlertTriangle,
+  },
+};
+
+const severityBadgeClasses: Record<AnnouncementSeverity, string> = {
+  info: "border-border bg-muted text-foreground",
+  warning: "border-border bg-accent text-accent-foreground",
+  error: "border-destructive/50 bg-destructive/10 text-destructive",
+};
+
+const statusBadgeClasses: Record<AnnouncementStatus, string> = {
+  "Live now": "border-transparent bg-primary text-primary-foreground",
+  Scheduled: "border-transparent bg-secondary text-secondary-foreground",
+  Expired: "border-border text-muted-foreground",
+  Draft: "border-transparent bg-secondary text-secondary-foreground",
+};
+
+const PreviewBanner = ({ form }: { form: AnnouncementForm }) => {
+  const style = severityStyles[form.severity];
+  const Icon = style.Icon;
+  const title = form.title.trim() || "Announcement title";
+  const description = form.description.trim();
+  const link = form.link_url.trim();
+  const linkLabel = form.link_label.trim() || form.link_label_en.trim();
+
+  return (
+    <div>
+      <div className="mb-2 text-sm font-medium">Live preview</div>
+      <div
+        role="status"
+        className={cn(
+          "flex min-h-9 w-full items-center gap-2 border px-3 py-1 text-sm",
+          style.className,
+        )}
+      >
+        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+          <span className="min-w-0 font-medium line-clamp-2">{title}</span>
+          {description && (
+            <span className="hidden min-w-0 truncate text-current/80 sm:inline">
+              — {description}
+            </span>
+          )}
+        </div>
+        {link && linkLabel && (
+          <a
+            href={link}
+            onClick={(event) => event.preventDefault()}
+            className="shrink-0 underline underline-offset-2"
+          >
+            {linkLabel}
+          </a>
+        )}
+        {form.dismissible && (
+          <button
+            type="button"
+            aria-label="Dismiss preview"
+            className="shrink-0 rounded-sm p-1 hover:bg-background/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Preview uses the Chinese title and description shown to zh visitors.
+      </p>
+    </div>
+  );
+};
+
+const AnnouncementFormDialog = ({
+  open,
+  editingId,
+  form,
+  formError,
+  isSaving,
+  saveError,
+  onOpenChange,
+  onChange,
+  onSubmit,
+}: {
+  open: boolean;
+  editingId: number | undefined;
+  form: AnnouncementForm;
+  formError: string | null;
+  isSaving: boolean;
+  saveError: unknown;
+  onOpenChange: (open: boolean) => void;
+  onChange: <K extends keyof AnnouncementForm>(
+    field: K,
+    value: AnnouncementForm[K],
+  ) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
+      <DialogHeader>
+        <DialogTitle>
+          {editingId === undefined
+            ? "Create announcement"
+            : "Edit announcement"}
+        </DialogTitle>
+        <DialogDescription>
+          This banner is visible to every visitor while it is active and within
+          its date window.
+        </DialogDescription>
+      </DialogHeader>
+
+      <form onSubmit={onSubmit} className="space-y-6">
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="announcement-title">Title (Chinese)</Label>
+            <Input
+              id="announcement-title"
+              value={form.title}
+              onChange={(event) => onChange("title", event.target.value)}
+              maxLength={200}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-title-en">Title (English)</Label>
+            <Input
+              id="announcement-title-en"
+              value={form.title_en}
+              onChange={(event) => onChange("title_en", event.target.value)}
+              maxLength={200}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-description">
+              Description (Chinese)
+            </Label>
+            <Textarea
+              id="announcement-description"
+              value={form.description}
+              onChange={(event) => onChange("description", event.target.value)}
+              maxLength={1000}
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-description-en">
+              Description (English)
+            </Label>
+            <Textarea
+              id="announcement-description-en"
+              value={form.description_en}
+              onChange={(event) =>
+                onChange("description_en", event.target.value)
+              }
+              maxLength={1000}
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          <div className="space-y-2 lg:col-span-2">
+            <Label htmlFor="announcement-link-url">Link URL</Label>
+            <Input
+              id="announcement-link-url"
+              value={form.link_url}
+              onChange={(event) => onChange("link_url", event.target.value)}
+              maxLength={500}
+              placeholder="/recruit or https://example.com"
+              inputMode="url"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-priority">Priority</Label>
+            <Input
+              id="announcement-priority"
+              type="number"
+              min={0}
+              max={100}
+              step={1}
+              value={form.priority}
+              onChange={(event) =>
+                onChange(
+                  "priority",
+                  event.target.value === "" ? "" : Number(event.target.value),
+                )
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-link-label">
+              Link label (Chinese)
+            </Label>
+            <Input
+              id="announcement-link-label"
+              value={form.link_label}
+              onChange={(event) => onChange("link_label", event.target.value)}
+              maxLength={100}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-link-label-en">
+              Link label (English)
+            </Label>
+            <Input
+              id="announcement-link-label-en"
+              value={form.link_label_en}
+              onChange={(event) =>
+                onChange("link_label_en", event.target.value)
+              }
+              maxLength={100}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-severity">Severity</Label>
+            <Select
+              value={form.severity}
+              onValueChange={(value) =>
+                onChange("severity", value as AnnouncementSeverity)
+              }
+            >
+              <SelectTrigger id="announcement-severity">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="info">Info</SelectItem>
+                <SelectItem value="warning">Warning</SelectItem>
+                <SelectItem value="error">Error</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="announcement-start-date">Start date</Label>
+            <Input
+              id="announcement-start-date"
+              type="datetime-local"
+              value={form.start_date}
+              onChange={(event) => onChange("start_date", event.target.value)}
+              step={60}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="announcement-end-date">End date</Label>
+            <Input
+              id="announcement-end-date"
+              type="datetime-local"
+              value={form.end_date}
+              onChange={(event) => onChange("end_date", event.target.value)}
+              step={60}
+              required
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-x-6 gap-y-3">
+          <label className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={form.active}
+              onCheckedChange={(checked) => onChange("active", checked)}
+            />
+            Active
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={form.dismissible}
+              onCheckedChange={(checked) => onChange("dismissible", checked)}
+            />
+            Dismissible
+          </label>
+        </div>
+
+        <PreviewBanner form={form} />
+
+        {formError && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            {formError}
+          </div>
+        )}
+        {saveError != null ? <ErrorState error={saveError} /> : null}
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSaving}>
+            {isSaving && <InlineSpinner />}
+            {editingId === undefined ? "Create announcement" : "Save changes"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  </Dialog>
+);
+
+const AdminAnnouncementsPage = () => {
+  const announcements = useAdminAnnouncements();
+  const saveAnnouncement = useSaveAnnouncement();
+  const deleteAnnouncement = useDeleteAnnouncement();
+  const { toast } = useToast();
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingId, setEditingId] = useState<number | undefined>();
+  const [form, setForm] = useState<AnnouncementForm>(emptyForm);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AdminAnnouncement | null>(
+    null,
+  );
+
+  const openCreate = () => {
+    saveAnnouncement.reset();
+    setEditingId(undefined);
+    setForm(emptyForm());
+    setFormError(null);
+    setEditorOpen(true);
+  };
+
+  const openEdit = (announcement: AdminAnnouncement) => {
+    saveAnnouncement.reset();
+    setEditingId(announcement.id);
+    setForm(announcementToForm(announcement));
+    setFormError(null);
+    setEditorOpen(true);
+  };
+
+  const updateForm = <K extends keyof AnnouncementForm>(
+    field: K,
+    value: AnnouncementForm[K],
+  ) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFormError(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const error = validateForm(form);
+    if (error) {
+      setFormError(error);
+      return;
+    }
+
+    saveAnnouncement.mutate(
+      { id: editingId, values: formToInput(form) },
+      {
+        onSuccess: () => {
+          setEditorOpen(false);
+          toast({
+            title:
+              editingId === undefined
+                ? "Announcement created"
+                : "Announcement saved",
+          });
+        },
+        onError: (error) => {
+          toast({
+            title: "Could not save announcement",
+            description: error.message,
+            variant: "destructive",
+          });
+        },
+      },
+    );
+  };
+
+  const handleDelete = () => {
+    if (!deleteTarget) return;
+    deleteAnnouncement.mutate(deleteTarget.id, {
+      onSuccess: () => {
+        setDeleteTarget(null);
+        toast({ title: "Announcement deleted" });
+      },
+      onError: (error) => {
+        toast({
+          title: "Could not delete announcement",
+          description: error.message,
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  return (
+    <>
+      <PageHeader
+        title="Announcements"
+        description="Manage the site-wide banner shown to every visitor."
+        actions={
+          <Button size="sm" onClick={openCreate}>
+            <Plus aria-hidden="true" />
+            New announcement
+          </Button>
+        }
+      />
+
+      {announcements.isError && <ErrorState error={announcements.error} />}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">All announcements</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="min-w-[220px]">Titles</TableHead>
+                  <TableHead className="w-[100px]">Severity</TableHead>
+                  <TableHead className="w-[110px]">Status</TableHead>
+                  <TableHead className="min-w-[210px]">Window</TableHead>
+                  <TableHead className="w-[90px]">Priority</TableHead>
+                  <TableHead className="w-[110px]">Options</TableHead>
+                  <TableHead className="w-[150px] text-right">
+                    Actions
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {announcements.isLoading &&
+                  Array.from({ length: 5 }).map((_, index) => (
+                    <TableRow key={index}>
+                      <TableCell colSpan={7}>
+                        <Skeleton className="h-5 w-full" />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+
+                {announcements.data?.map((announcement) => {
+                  const status = getStatus(announcement);
+                  return (
+                    <TableRow key={announcement.id}>
+                      <TableCell className="max-w-[300px]">
+                        <div className="truncate font-medium">
+                          {announcement.title}
+                        </div>
+                        <div className="truncate text-xs text-muted-foreground">
+                          {announcement.title_en || "—"}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={
+                            severityBadgeClasses[announcement.severity]
+                          }
+                        >
+                          {announcement.severity}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={statusBadgeClasses[status]}
+                        >
+                          {status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="whitespace-nowrap text-xs">
+                          <Mono>{formatDateTime(announcement.start_date)}</Mono>
+                          <span className="px-1 text-muted-foreground">→</span>
+                          <Mono>{formatDateTime(announcement.end_date)}</Mono>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Mono>P{announcement.priority}</Mono>
+                      </TableCell>
+                      <TableCell>
+                        <span className="text-xs text-muted-foreground">
+                          {announcement.dismissible ? "Dismissible" : "Sticky"}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap justify-end gap-1">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => openEdit(announcement)}
+                          >
+                            <Pencil aria-hidden="true" />
+                            <span className="sr-only sm:not-sr-only">Edit</span>
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive hover:text-destructive"
+                            onClick={() => setDeleteTarget(announcement)}
+                          >
+                            <Trash2 aria-hidden="true" />
+                            <span className="sr-only sm:not-sr-only">
+                              Delete
+                            </span>
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+
+          {!announcements.isLoading && announcements.data?.length === 0 && (
+            <EmptyState>No announcements have been created.</EmptyState>
+          )}
+        </CardContent>
+      </Card>
+
+      <AnnouncementFormDialog
+        open={editorOpen}
+        editingId={editingId}
+        form={form}
+        formError={formError}
+        isSaving={saveAnnouncement.isPending}
+        saveError={saveAnnouncement.isError ? saveAnnouncement.error : null}
+        onOpenChange={setEditorOpen}
+        onChange={updateForm}
+        onSubmit={handleSubmit}
+      />
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !deleteAnnouncement.isPending) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete announcement?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes “{deleteTarget?.title}” from the banner
+              list. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteAnnouncement.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteAnnouncement.isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                handleDelete();
+              }}
+            >
+              {deleteAnnouncement.isPending && <InlineSpinner />}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+};
 
 export default AdminAnnouncementsPage;

--- a/apps/web/src/app/[lang]/admin/announcements/page.tsx
+++ b/apps/web/src/app/[lang]/admin/announcements/page.tsx
@@ -1,0 +1,5 @@
+import { PageHeader } from "../components";
+
+const AdminAnnouncementsPage = () => <PageHeader title="Announcements" />;
+
+export default AdminAnnouncementsPage;

--- a/apps/web/src/app/[lang]/admin/api.ts
+++ b/apps/web/src/app/[lang]/admin/api.ts
@@ -17,6 +17,25 @@ import authClient from "@/config/auth";
 
 export type AdminRole = "USER" | "ADMIN" | "SUPERUSER";
 
+/**
+ * The consent scopes, mirroring `VALID_SCOPES` in
+ * `services/secure-api/src/const/scopes.ts`. These are the ones a user is asked
+ * to approve, and the ones the registration form offers as checkboxes.
+ *
+ * A client's stored `scopes` is deliberately wider than this: it can also hold
+ * a machine-to-machine `introspect:<clientId>` grant, which no consent screen
+ * ever shows. Those are carried through an edit untouched rather than being
+ * dropped by a form that cannot name them.
+ */
+export type AdminScope =
+  | "openid"
+  | "profile"
+  | "email"
+  | "offline_access"
+  | "kv"
+  | "calendar"
+  | "planner";
+
 export type AdminIdentity = {
   userId: string;
   name: string;
@@ -79,7 +98,11 @@ export type AdminAnnouncement = {
   link_url: string | null;
   link_label: string | null;
   link_label_en: string | null;
-  severity: AnnouncementSeverity;
+  // Reads are lenient and writes are strict, because they are not the same
+  // set: rows written before the API enforced an enum hold values like
+  // "danger", and claiming otherwise here would only move the surprise to
+  // wherever the value is finally used.
+  severity: string;
   start_date: string;
   end_date: string;
   active: boolean;
@@ -90,8 +113,8 @@ export type AdminAnnouncement = {
 
 export type AdminAnnouncementInput = Omit<
   AdminAnnouncement,
-  "id" | "created_at"
->;
+  "id" | "created_at" | "severity"
+> & { severity: AnnouncementSeverity };
 
 export type AdminClient = {
   id: string;

--- a/apps/web/src/app/[lang]/admin/api.ts
+++ b/apps/web/src/app/[lang]/admin/api.ts
@@ -68,6 +68,8 @@ export type AdminStats = {
   };
 };
 
+export type AnnouncementSeverity = "info" | "warning" | "error";
+
 export type AdminAnnouncement = {
   id: number;
   title: string;
@@ -77,7 +79,7 @@ export type AdminAnnouncement = {
   link_url: string | null;
   link_label: string | null;
   link_label_en: string | null;
-  severity: string;
+  severity: AnnouncementSeverity;
   start_date: string;
   end_date: string;
   active: boolean;

--- a/apps/web/src/app/[lang]/admin/api.ts
+++ b/apps/web/src/app/[lang]/admin/api.ts
@@ -513,6 +513,75 @@ export const useAdminOAuthClients = () => {
   });
 };
 
+export type AdminOAuthClientInput = {
+  clientId: string;
+  name: string | null;
+  clientUri: string | null;
+  firstParty: boolean;
+  redirectUris: string[];
+  logoutUris: string[];
+  scopes: string[];
+  confidential: boolean;
+};
+
+export type AdminOAuthClientSecret = AdminClient & {
+  clientSecret: string | null;
+};
+
+export const useCreateOAuthClient = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async (values: AdminOAuthClientInput) => {
+      const response = await authClient.api.admin.clients.$post(
+        { json: values },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminOAuthClientSecret>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useUpdateOAuthClient = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async ({
+      clientId,
+      values,
+    }: {
+      clientId: string;
+      values: Omit<AdminOAuthClientInput, "clientId">;
+    }) => {
+      const response = await authClient.api.admin.clients[":clientId"].$patch(
+        { param: { clientId }, json: values },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminClient>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useDeleteOAuthClient = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async (clientId: string) => {
+      const response = await authClient.api.admin.clients[":clientId"].$delete(
+        { param: { clientId } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<{ deleted: boolean }>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
 export const useRotateClientSecret = () => {
   const token = useAdminToken();
   const invalidate = useInvalidateAdmin();

--- a/apps/web/src/app/[lang]/admin/api.ts
+++ b/apps/web/src/app/[lang]/admin/api.ts
@@ -1,0 +1,564 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
+import { useAuth } from "react-oidc-context";
+import authClient from "@/config/auth";
+
+/**
+ * Data access for the admin center.
+ *
+ * Every call carries the signed-in staff member's own access token — there is
+ * no service account and no shared admin key, so the audit trail on the server
+ * always names a person.
+ */
+
+export type AdminRole = "USER" | "ADMIN" | "SUPERUSER";
+
+export type AdminIdentity = {
+  userId: string;
+  name: string;
+  nameEn: string;
+  email: string;
+  role: AdminRole;
+  isAdmin: boolean;
+  isSuperuser: boolean;
+};
+
+export type AdminUser = {
+  id: string;
+  userId: string;
+  name: string;
+  nameEn: string;
+  email: string;
+  inschool: boolean;
+  role: AdminRole;
+  banned: boolean;
+  bannedReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminStats = {
+  accounts: {
+    total: number;
+    new7d: number;
+    new30d: number;
+    banned: number;
+    admins: number;
+    active7d: number;
+    active30d: number;
+  };
+  sessions: {
+    active: number;
+    accessTokens: number;
+    refreshTokens: number;
+    apiKeys: number;
+    calendarShareTokens: number;
+  };
+  oauth: { clients: number; consents: number };
+  content: {
+    courses: number | null;
+    comments: number | null;
+    delayReports: number | null;
+    alerts: number | null;
+    contentUsers: number | null;
+  };
+};
+
+export type AdminAnnouncement = {
+  id: number;
+  title: string;
+  title_en: string | null;
+  description: string | null;
+  description_en: string | null;
+  link_url: string | null;
+  link_label: string | null;
+  link_label_en: string | null;
+  severity: string;
+  start_date: string;
+  end_date: string;
+  active: boolean;
+  dismissible: boolean;
+  priority: number;
+  created_at: string;
+};
+
+export type AdminAnnouncementInput = Omit<
+  AdminAnnouncement,
+  "id" | "created_at"
+>;
+
+export type AdminClient = {
+  id: string;
+  clientId: string;
+  name: string | null;
+  clientUri: string | null;
+  firstParty: boolean;
+  redirectUris: string[];
+  logoutUris: string[];
+  scopes: string[];
+  confidential: boolean;
+  consents: number;
+};
+
+export type AdminAuditEntry = {
+  id: string;
+  actorId: string;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  metadata: unknown;
+  createdAt: string;
+  actor: { userId: string; name: string; nameEn: string } | null;
+};
+
+/**
+ * The access token for the current staff session.
+ *
+ * Read at call time rather than captured, so a silent renew mid-session does
+ * not leave a mutation holding a token that expired three minutes ago.
+ */
+export const useAdminToken = () => {
+  const auth = useAuth();
+  return auth.isAuthenticated ? (auth.user?.access_token ?? null) : null;
+};
+
+const authHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+});
+
+/**
+ * Turn a non-2xx admin response into an Error carrying the server's own
+ * explanation. The API answers with `error_description` for anything a person
+ * can act on ("You cannot ban yourself"), and swallowing that in favour of
+ * "Request failed" would make the UI strictly less useful than curl.
+ */
+const unwrap = async <T>(response: Response): Promise<T> => {
+  if (response.ok) return (await response.json()) as T;
+
+  let message = `Request failed (${response.status})`;
+  try {
+    const body = (await response.json()) as {
+      error?: string;
+      error_description?: string;
+    };
+    message = body.error_description ?? body.error ?? message;
+  } catch {
+    // A proxy error page is not JSON; the status line is all we have.
+  }
+  throw new Error(message);
+};
+
+export const adminKeys = {
+  me: ["admin", "me"] as const,
+  stats: ["admin", "stats"] as const,
+  signups: (days: number) => ["admin", "stats", "signups", days] as const,
+  clientUsage: ["admin", "stats", "clients"] as const,
+  users: (params: unknown) => ["admin", "users", params] as const,
+  user: (userId: string) => ["admin", "user", userId] as const,
+  announcements: ["admin", "announcements"] as const,
+  oauthClients: ["admin", "clients"] as const,
+  audit: (params: unknown) => ["admin", "audit", params] as const,
+};
+
+/**
+ * Who the viewer is, as far as the admin center is concerned.
+ *
+ * Returns `null` for a signed-out visitor rather than throwing, so the gate can
+ * treat "not signed in" and "not staff" as the same dead end.
+ */
+export const useAdminIdentity = () => {
+  const token = useAdminToken();
+  const auth = useAuth();
+
+  return useQuery<AdminIdentity | null>({
+    queryKey: adminKeys.me,
+    // The identity decides whether the rest of the console renders at all;
+    // re-checking on focus means a revoked role takes effect on tab switch.
+    staleTime: 60_000,
+    enabled: !auth.isLoading,
+    queryFn: async () => {
+      if (!token) return null;
+      const response = await authClient.api.admin.me.$get(
+        {},
+        { headers: authHeaders(token) },
+      );
+      if (response.status === 401 || response.status === 403) return null;
+      return unwrap<AdminIdentity>(response as unknown as Response);
+    },
+  });
+};
+
+const requireToken = (token: string | null) => {
+  if (!token) throw new Error("Your session has expired. Sign in again.");
+  return token;
+};
+
+export const useAdminStats = () => {
+  const token = useAdminToken();
+  return useQuery<AdminStats>({
+    queryKey: adminKeys.stats,
+    enabled: Boolean(token),
+    queryFn: async () => {
+      const response = await authClient.api.admin.stats.$get(
+        {},
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminStats>(response as unknown as Response);
+    },
+  });
+};
+
+export const useAdminSignups = (days: number) => {
+  const token = useAdminToken();
+  return useQuery<{ days: number; series: { day: string; count: number }[] }>({
+    queryKey: adminKeys.signups(days),
+    enabled: Boolean(token),
+    queryFn: async () => {
+      const response = await authClient.api.admin.stats.signups.$get(
+        { query: { days: String(days) } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap(response as unknown as Response);
+    },
+  });
+};
+
+export const useAdminClientUsage = () => {
+  const token = useAdminToken();
+  return useQuery<
+    {
+      clientId: string;
+      name: string | null;
+      firstParty: boolean;
+      tokens: number;
+    }[]
+  >({
+    queryKey: adminKeys.clientUsage,
+    enabled: Boolean(token),
+    queryFn: async () => {
+      const response = await authClient.api.admin.stats.clients.$get(
+        {},
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap(response as unknown as Response);
+    },
+  });
+};
+
+export type AdminUserQuery = {
+  q?: string;
+  role?: AdminRole;
+  banned?: "true" | "false";
+  page: number;
+  pageSize: number;
+};
+
+export const useAdminUsers = (
+  params: AdminUserQuery,
+  options?: Partial<
+    UseQueryOptions<{
+      total: number;
+      page: number;
+      pageSize: number;
+      users: AdminUser[];
+    }>
+  >,
+) => {
+  const token = useAdminToken();
+  return useQuery({
+    queryKey: adminKeys.users(params),
+    enabled: Boolean(token),
+    ...options,
+    queryFn: async () => {
+      const response = await authClient.api.admin.users.$get(
+        {
+          query: {
+            ...(params.q ? { q: params.q } : {}),
+            ...(params.role ? { role: params.role } : {}),
+            ...(params.banned ? { banned: params.banned } : {}),
+            page: String(params.page),
+            pageSize: String(params.pageSize),
+          },
+        },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<{
+        total: number;
+        page: number;
+        pageSize: number;
+        users: AdminUser[];
+      }>(response as unknown as Response);
+    },
+  });
+};
+
+export type AdminUserDetail = {
+  user: AdminUser;
+  bootstrapSuperuser: boolean;
+  sessions: {
+    id: string;
+    state: string;
+    createdAt: string;
+    authenticatedAt: string | null;
+    expiresAt: string;
+  }[];
+  tokens: {
+    id: string;
+    type: string;
+    clientId: string;
+    scopes: string[];
+    createdAt: string;
+    expiresAt: string;
+  }[];
+  apiKeys: {
+    id: string;
+    name: string;
+    scopes: string[];
+    createdAt: string;
+    lastUsedAt: string | null;
+    expiresAt: string | null;
+    isRevoked: boolean;
+  }[];
+  shareTokens: {
+    id: string;
+    name: string;
+    createdAt: string;
+    lastUsedAt: string | null;
+    expiresAt: string | null;
+    revokedAt: string | null;
+    includeFullDetails: boolean;
+  }[];
+  consents: {
+    id: string;
+    clientId: string;
+    scopes: string[];
+    grantedAt: string;
+    updatedAt: string;
+  }[];
+};
+
+export const useAdminUser = (userId: string) => {
+  const token = useAdminToken();
+  return useQuery<AdminUserDetail>({
+    queryKey: adminKeys.user(userId),
+    enabled: Boolean(token && userId),
+    queryFn: async () => {
+      const response = await authClient.api.admin.users[":userId"].$get(
+        { param: { userId } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminUserDetail>(response as unknown as Response);
+    },
+  });
+};
+
+/**
+ * Invalidate everything a user-affecting write could have changed.
+ *
+ * A ban revokes tokens and moves the banned count on the overview, so the
+ * cheapest correct answer is to drop the whole admin namespace rather than
+ * enumerate which of six keys happened to be on screen.
+ */
+const useInvalidateAdmin = () => {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: ["admin"] });
+};
+
+export const useSetUserRole = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async ({
+      userId,
+      role,
+    }: {
+      userId: string;
+      role: AdminRole;
+    }) => {
+      const response = await authClient.api.admin.users[":userId"].role.$patch(
+        { param: { userId }, json: { role } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminUser>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useSetUserBan = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async ({
+      userId,
+      banned,
+      reason,
+    }: {
+      userId: string;
+      banned: boolean;
+      reason?: string;
+    }) => {
+      const response = await authClient.api.admin.users[":userId"].ban.$patch(
+        {
+          param: { userId },
+          json: { banned, ...(reason ? { reason } : {}) },
+        },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminUser>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useRevokeUserSessions = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async ({ userId }: { userId: string }) => {
+      const response = await authClient.api.admin.users[
+        ":userId"
+      ].sessions.$delete(
+        { param: { userId } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<{ tokens: number; sessions: number }>(
+        response as unknown as Response,
+      );
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useAdminAnnouncements = () => {
+  const token = useAdminToken();
+  return useQuery<AdminAnnouncement[]>({
+    queryKey: adminKeys.announcements,
+    enabled: Boolean(token),
+    queryFn: async () => {
+      const response = await authClient.api.admin.announcements.$get(
+        {},
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminAnnouncement[]>(response as unknown as Response);
+    },
+  });
+};
+
+export const useSaveAnnouncement = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      values,
+    }: {
+      id?: number;
+      values: AdminAnnouncementInput;
+    }) => {
+      const headers = authHeaders(requireToken(token));
+      const response = id
+        ? await authClient.api.admin.announcements[":id"].$patch(
+            { param: { id: String(id) }, json: values },
+            { headers },
+          )
+        : await authClient.api.admin.announcements.$post(
+            { json: values },
+            { headers },
+          );
+      return unwrap<AdminAnnouncement>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useDeleteAnnouncement = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const response = await authClient.api.admin.announcements[":id"].$delete(
+        { param: { id: String(id) } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<{ deleted: boolean }>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useAdminOAuthClients = () => {
+  const token = useAdminToken();
+  return useQuery<AdminClient[]>({
+    queryKey: adminKeys.oauthClients,
+    enabled: Boolean(token),
+    queryFn: async () => {
+      const response = await authClient.api.admin.clients.$get(
+        {},
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<AdminClient[]>(response as unknown as Response);
+    },
+  });
+};
+
+export const useRotateClientSecret = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async (clientId: string) => {
+      const response = await authClient.api.admin.clients[":clientId"][
+        "rotate-secret"
+      ].$post(
+        { param: { clientId } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<{ clientId: string; clientSecret: string }>(
+        response as unknown as Response,
+      );
+    },
+    onSuccess: invalidate,
+  });
+};
+
+export const useAdminAudit = (params: {
+  action?: string;
+  actorId?: string;
+  page: number;
+  pageSize: number;
+}) => {
+  const token = useAdminToken();
+  return useQuery<{
+    total: number;
+    page: number;
+    pageSize: number;
+    entries: AdminAuditEntry[];
+  }>({
+    queryKey: adminKeys.audit(params),
+    enabled: Boolean(token),
+    queryFn: async () => {
+      const response = await authClient.api.admin.audit.$get(
+        {
+          query: {
+            ...(params.action ? { action: params.action } : {}),
+            ...(params.actorId ? { actorId: params.actorId } : {}),
+            page: String(params.page),
+            pageSize: String(params.pageSize),
+          },
+        },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap(response as unknown as Response);
+    },
+  });
+};

--- a/apps/web/src/app/[lang]/admin/audit/page.tsx
+++ b/apps/web/src/app/[lang]/admin/audit/page.tsx
@@ -1,5 +1,370 @@
-import { PageHeader } from "../components";
+import { useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import { useDebounceValue } from "usehooks-ts";
+import {
+  Badge,
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@courseweb/ui";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+import {
+  EmptyState,
+  ErrorState,
+  Mono,
+  PageHeader,
+  formatDateTime,
+  relativeTime,
+} from "../components";
+import { useAdminAudit } from "../api";
 
-const AdminAuditPage = () => <PageHeader title="Audit Log" />;
+const PAGE_SIZE = 25;
+const ACTION_PREFIXES = ["user.", "announcement.", "client."] as const;
+
+type JsonObject = Record<string, unknown>;
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const jsonText = (value: unknown) =>
+  JSON.stringify(value, null, 2) ?? String(value);
+
+const MetadataDisclosure = ({ value }: { value: unknown }) => (
+  <details className="max-w-[280px]">
+    <summary className="cursor-pointer text-xs text-muted-foreground">
+      View metadata
+    </summary>
+    <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted/50 p-2 text-[0.7rem] leading-4">
+      {jsonText(value)}
+    </pre>
+  </details>
+);
+
+const Metadata = ({ action, value }: { action: string; value: unknown }) => {
+  if (!isJsonObject(value)) {
+    return value == null ? (
+      <span>—</span>
+    ) : (
+      <MetadataDisclosure value={value} />
+    );
+  }
+
+  const from = value.from;
+  const to = value.to;
+  if (
+    action === "user.role.update" &&
+    typeof from === "string" &&
+    typeof to === "string"
+  ) {
+    return (
+      <Mono>
+        {from} -&gt; {to}
+      </Mono>
+    );
+  }
+
+  if (action === "user.ban") {
+    return (
+      <span>
+        Reason:{" "}
+        {typeof value.reason === "string" ? value.reason : "Not provided"}
+      </span>
+    );
+  }
+
+  if (action === "user.unban" && typeof value.reason === "string") {
+    return <span>Reason: {value.reason}</span>;
+  }
+
+  if (
+    action === "user.sessions.revoke" &&
+    typeof value.sessions === "number" &&
+    typeof value.tokens === "number"
+  ) {
+    return (
+      <span>
+        {value.sessions} session{value.sessions === 1 ? "" : "s"} ·{" "}
+        {value.tokens} token
+        {value.tokens === 1 ? "" : "s"}
+      </span>
+    );
+  }
+
+  if (
+    Array.isArray(value.fields) &&
+    value.fields.every((field) => typeof field === "string")
+  ) {
+    return <span>Fields: {value.fields.join(", ") || "none"}</span>;
+  }
+
+  if (typeof value.title === "string") {
+    return (
+      <span>
+        Title: {value.title}
+        {typeof value.active === "boolean" && (
+          <span className="text-muted-foreground">
+            {value.active ? " · active" : " · inactive"}
+          </span>
+        )}
+      </span>
+    );
+  }
+
+  if (typeof value.name === "string") return <span>Name: {value.name}</span>;
+
+  if (
+    typeof value.firstParty === "boolean" ||
+    typeof value.confidential === "boolean"
+  ) {
+    return (
+      <span>
+        {value.firstParty === true ? "First-party" : "Third-party"}
+        {typeof value.confidential === "boolean" &&
+          (value.confidential ? " · confidential" : " · public")}
+      </span>
+    );
+  }
+
+  if (Object.keys(value).length === 0) return <span>—</span>;
+  return <MetadataDisclosure value={value} />;
+};
+
+const actionPrefix = (action: string) =>
+  ACTION_PREFIXES.find((prefix) => action.startsWith(prefix)) ?? "all";
+
+const isDestructiveAction = (action: string) =>
+  action.endsWith(".ban") ||
+  action.endsWith(".delete") ||
+  action.endsWith(".rotate_secret");
+
+/**
+ * The audit trail is intentionally dense: staff need to scan who changed what
+ * without opening a second view for every event.
+ */
+const AdminAuditPage = () => {
+  const { lang } = useParams<{ lang: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+  const action = searchParams.get("action") ?? "";
+  const actorId = searchParams.get("actorId") ?? "";
+
+  const [actionInput, setActionInput] = useState(action);
+  const [actorInput, setActorInput] = useState(actorId);
+  // Action searches are commonly typed one character at a time; debouncing
+  // keeps that from turning one filter change into a request per keystroke.
+  const [debouncedAction] = useDebounceValue(actionInput, 300);
+
+  const query = useAdminAudit({
+    action: debouncedAction.trim() || undefined,
+    actorId: actorId.trim() || undefined,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const updateParam = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value === "all" || value === "") next.delete(key);
+    else next.set(key, value);
+    // A changed filter can make the current page empty, so start it over.
+    if (key !== "page") next.delete("page");
+    setSearchParams(next, { replace: true });
+  };
+
+  const total = query.data?.total ?? 0;
+  const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <>
+      <PageHeader
+        title="Audit Log"
+        description="A read-only record of changes made in the admin center."
+      />
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[220px] flex-1">
+          <Search
+            className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <Input
+            className="pl-8"
+            placeholder="Action, e.g. role.update"
+            value={actionInput}
+            onChange={(event) => {
+              setActionInput(event.target.value);
+              updateParam("action", event.target.value);
+            }}
+            aria-label="Filter by action"
+          />
+        </div>
+
+        <Input
+          className="min-w-[180px] flex-1 sm:max-w-[220px]"
+          placeholder="Actor user ID"
+          value={actorInput}
+          onChange={(event) => {
+            setActorInput(event.target.value);
+            updateParam("actorId", event.target.value);
+          }}
+          aria-label="Filter by actor user ID"
+        />
+
+        <Select
+          value={actionPrefix(action)}
+          onValueChange={(value) => {
+            const nextValue = value === "all" ? "" : value;
+            setActionInput(nextValue);
+            updateParam("action", nextValue);
+          }}
+        >
+          <SelectTrigger
+            className="w-[180px]"
+            aria-label="Filter by action prefix"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All action groups</SelectItem>
+            {ACTION_PREFIXES.map((prefix) => (
+              <SelectItem key={prefix} value={prefix}>
+                {prefix}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {query.isError && <ErrorState error={query.error} />}
+
+      <div className="overflow-x-auto rounded-md border bg-background">
+        <Table className="min-w-[900px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[150px]">When</TableHead>
+              <TableHead className="w-[170px]">Who</TableHead>
+              <TableHead className="w-[170px]">Action</TableHead>
+              <TableHead className="w-[170px]">Target</TableHead>
+              <TableHead>Details</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {query.isLoading &&
+              Array.from({ length: 8 }).map((_, index) => (
+                <TableRow key={index}>
+                  <TableCell colSpan={5}>
+                    <Skeleton className="h-5 w-full" />
+                  </TableCell>
+                </TableRow>
+              ))}
+
+            {query.data?.entries.map((entry) => {
+              const actorName =
+                entry.actor?.name || entry.actor?.nameEn || "Unknown actor";
+              const target = entry.targetId ? (
+                entry.targetType === "user" ? (
+                  <Link
+                    to={`/${lang}/admin/users/${entry.targetId}`}
+                    className="font-mono text-xs underline-offset-2 hover:underline"
+                  >
+                    {entry.targetId}
+                  </Link>
+                ) : (
+                  <Mono>{entry.targetId}</Mono>
+                )
+              ) : (
+                <span>—</span>
+              );
+
+              return (
+                <TableRow key={entry.id}>
+                  <TableCell>
+                    <Mono>{formatDateTime(entry.createdAt)}</Mono>
+                    <div className="text-xs text-muted-foreground">
+                      {relativeTime(entry.createdAt)}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="truncate">{actorName}</div>
+                    <Link
+                      to={`/${lang}/admin/users/${entry.actorId}`}
+                      className="font-mono text-xs underline-offset-2 hover:underline"
+                    >
+                      {entry.actorId}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        isDestructiveAction(entry.action)
+                          ? "destructive"
+                          : "secondary"
+                      }
+                    >
+                      {entry.action}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="text-xs text-muted-foreground">
+                      {entry.targetType ?? "—"}
+                    </div>
+                    {target}
+                  </TableCell>
+                  <TableCell>
+                    <Metadata action={entry.action} value={entry.metadata} />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+
+        {!query.isLoading && query.data?.entries.length === 0 && (
+          <EmptyState>No audit entries match those filters.</EmptyState>
+        )}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+        <span>
+          {total.toLocaleString()} entr{total === 1 ? "y" : "ies"}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => updateParam("page", String(page - 1))}
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+            Previous
+          </Button>
+          <span className="tabular-nums">
+            {page} / {lastPage}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= lastPage}
+            onClick={() => updateParam("page", String(page + 1))}
+          >
+            Next
+            <ChevronRight className="h-4 w-4" aria-hidden />
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
 
 export default AdminAuditPage;

--- a/apps/web/src/app/[lang]/admin/audit/page.tsx
+++ b/apps/web/src/app/[lang]/admin/audit/page.tsx
@@ -1,0 +1,5 @@
+import { PageHeader } from "../components";
+
+const AdminAuditPage = () => <PageHeader title="Audit Log" />;
+
+export default AdminAuditPage;

--- a/apps/web/src/app/[lang]/admin/clients/page.tsx
+++ b/apps/web/src/app/[lang]/admin/clients/page.tsx
@@ -60,9 +60,10 @@ import {
   type AdminClient,
   type AdminIdentity,
   type AdminOAuthClientInput,
+  type AdminScope,
 } from "../api";
 
-const VALID_SCOPES = [
+const VALID_SCOPES: { value: AdminScope; description: string }[] = [
   { value: "openid", description: "Stable subject identifier" },
   { value: "profile", description: "Name, English name and school status" },
   { value: "email", description: "Email address" },
@@ -70,7 +71,7 @@ const VALID_SCOPES = [
   { value: "kv", description: "Key-value storage" },
   { value: "calendar", description: "Calendar data" },
   { value: "planner", description: "Planner data" },
-] as const;
+];
 
 type ClientFormValues = {
   clientId: string;
@@ -80,6 +81,9 @@ type ClientFormValues = {
   confidential: boolean;
   redirectUris: string[];
   logoutUris: string[];
+  // Wider than the checkbox list: an existing client may carry an
+  // `introspect:<clientId>` grant that this form has no checkbox for, and
+  // editing its name must not quietly revoke it.
   scopes: string[];
 };
 
@@ -316,7 +320,13 @@ const ClientFormDialog = ({
     }));
   };
 
-  const toggleScope = (scope: string, checked: boolean) => {
+  // Anything on the client that the checkbox list above cannot represent.
+  const consentScopes = VALID_SCOPES.map((scope) => scope.value) as string[];
+  const otherScopes = values.scopes.filter(
+    (scope) => !consentScopes.includes(scope),
+  );
+
+  const toggleScope = (scope: AdminScope, checked: boolean) => {
     setValues((current) => ({
       ...current,
       scopes: checked
@@ -492,6 +502,19 @@ const ClientFormDialog = ({
                 </label>
               ))}
             </div>
+            {/* Shown rather than hidden: these are real grants with no checkbox,
+                and an operator who cannot see them has no way to know an edit
+                is keeping them. */}
+            {otherScopes.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                Also granted, and kept on save:{" "}
+                {otherScopes.map((scope) => (
+                  <span key={scope} className="font-mono">
+                    {scope}{" "}
+                  </span>
+                ))}
+              </p>
+            )}
             <FieldError message={errors.scopes} />
           </div>
 

--- a/apps/web/src/app/[lang]/admin/clients/page.tsx
+++ b/apps/web/src/app/[lang]/admin/clients/page.tsx
@@ -1,0 +1,5 @@
+import { PageHeader } from "../components";
+
+const AdminClientsPage = () => <PageHeader title="OAuth Clients" />;
+
+export default AdminClientsPage;

--- a/apps/web/src/app/[lang]/admin/clients/page.tsx
+++ b/apps/web/src/app/[lang]/admin/clients/page.tsx
@@ -1,5 +1,1003 @@
-import { PageHeader } from "../components";
+import { Fragment, useEffect, useState, type FormEvent } from "react";
+import { useOutletContext } from "react-router-dom";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  Switch,
+  useToast,
+} from "@courseweb/ui";
+import {
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  Pencil,
+  Plus,
+  RefreshCw,
+  ShieldAlert,
+  Trash2,
+} from "lucide-react";
+import {
+  EmptyState,
+  ErrorState,
+  InlineSpinner,
+  Mono,
+  PageHeader,
+} from "../components";
+import {
+  useAdminOAuthClients,
+  useCreateOAuthClient,
+  useDeleteOAuthClient,
+  useRotateClientSecret,
+  useUpdateOAuthClient,
+  type AdminClient,
+  type AdminIdentity,
+  type AdminOAuthClientInput,
+} from "../api";
 
-const AdminClientsPage = () => <PageHeader title="OAuth Clients" />;
+const VALID_SCOPES = [
+  { value: "openid", description: "Stable subject identifier" },
+  { value: "profile", description: "Name, English name and school status" },
+  { value: "email", description: "Email address" },
+  { value: "offline_access", description: "Long-lived refresh access" },
+  { value: "kv", description: "Key-value storage" },
+  { value: "calendar", description: "Calendar data" },
+  { value: "planner", description: "Planner data" },
+] as const;
+
+type ClientFormValues = {
+  clientId: string;
+  name: string;
+  clientUri: string;
+  firstParty: boolean;
+  confidential: boolean;
+  redirectUris: string[];
+  logoutUris: string[];
+  scopes: string[];
+};
+
+type ClientFormErrors = Partial<
+  Record<
+    "clientId" | "clientUri" | "redirectUris" | "logoutUris" | "scopes",
+    string
+  >
+>;
+
+type SecretNotice = {
+  clientId: string;
+  clientSecret: string | null;
+  action: "created" | "rotated";
+};
+
+const emptyClientForm = (): ClientFormValues => ({
+  clientId: "",
+  name: "",
+  clientUri: "",
+  firstParty: false,
+  confidential: false,
+  redirectUris: [""],
+  logoutUris: [],
+  scopes: [],
+});
+
+const formFromClient = (client: AdminClient): ClientFormValues => ({
+  clientId: client.clientId,
+  name: client.name ?? "",
+  clientUri: client.clientUri ?? "",
+  firstParty: client.firstParty,
+  confidential: client.confidential,
+  redirectUris: [...client.redirectUris],
+  logoutUris: [...client.logoutUris],
+  scopes: [...client.scopes],
+});
+
+const isValidUrl = (value: string) => {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const validateClientForm = (
+  values: ClientFormValues,
+  isCreate: boolean,
+): ClientFormErrors => {
+  const errors: ClientFormErrors = {};
+  const clientId = values.clientId.trim();
+
+  if (isCreate) {
+    if (clientId.length < 3 || clientId.length > 64) {
+      errors.clientId = "Client ID must be between 3 and 64 characters.";
+    } else if (!/^[a-zA-Z0-9._-]+$/.test(clientId)) {
+      errors.clientId =
+        "Client ID may use only letters, digits, periods, underscores and hyphens.";
+    }
+  }
+
+  if (values.clientUri.trim() && !isValidUrl(values.clientUri.trim())) {
+    errors.clientUri = "Client URI must be a valid URL.";
+  }
+
+  if (values.redirectUris.length === 0) {
+    errors.redirectUris = "Add at least one redirect URI.";
+  } else if (values.redirectUris.some((uri) => !isValidUrl(uri.trim()))) {
+    errors.redirectUris = "Every redirect URI must be a valid URL.";
+  }
+
+  if (values.logoutUris.some((uri) => !isValidUrl(uri.trim()))) {
+    errors.logoutUris = "Every logout URI must be a valid URL.";
+  }
+
+  if (values.scopes.length === 0) {
+    errors.scopes = "Select at least one scope.";
+  }
+
+  return errors;
+};
+
+const toApiInput = (values: ClientFormValues): AdminOAuthClientInput => ({
+  clientId: values.clientId.trim(),
+  name: values.name.trim() || null,
+  clientUri: values.clientUri.trim() || null,
+  firstParty: values.firstParty,
+  confidential: values.confidential,
+  redirectUris: values.redirectUris.map((uri) => uri.trim()),
+  logoutUris: values.logoutUris.map((uri) => uri.trim()),
+  scopes: values.scopes,
+});
+
+const FieldError = ({ message }: { message?: string }) =>
+  message ? (
+    <p className="text-sm text-destructive" role="alert">
+      {message}
+    </p>
+  ) : null;
+
+const UriListEditor = ({
+  label,
+  description,
+  values,
+  onChange,
+  onAdd,
+  onRemove,
+  error,
+  required,
+  idPrefix,
+}: {
+  label: string;
+  description: string;
+  values: string[];
+  onChange: (index: number, value: string) => void;
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+  error?: string;
+  required?: boolean;
+  idPrefix: string;
+}) => (
+  <div className="space-y-2">
+    <div className="flex flex-wrap items-start justify-between gap-2">
+      <div>
+        <Label>
+          {label}
+          {required && <span className="text-destructive"> *</span>}
+        </Label>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Button type="button" variant="outline" size="sm" onClick={onAdd}>
+        <Plus aria-hidden />
+        Add URI
+      </Button>
+    </div>
+
+    {values.length === 0 ? (
+      <p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+        No URIs configured.
+      </p>
+    ) : (
+      <div className="space-y-2">
+        {values.map((value, index) => (
+          <div key={`${idPrefix}-${index}`} className="flex items-start gap-2">
+            <Input
+              id={`${idPrefix}-${index}`}
+              type="url"
+              inputMode="url"
+              placeholder="https://example.com/callback"
+              value={value}
+              onChange={(event) => onChange(index, event.target.value)}
+              aria-label={`${label} ${index + 1}`}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => onRemove(index)}
+              aria-label={`Remove ${label.toLowerCase()} ${index + 1}`}
+            >
+              <Trash2 aria-hidden />
+            </Button>
+          </div>
+        ))}
+      </div>
+    )}
+
+    <FieldError message={error} />
+  </div>
+);
+
+const ClientFormDialog = ({
+  open,
+  onOpenChange,
+  mode,
+  client,
+  pending,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  client?: AdminClient;
+  pending: boolean;
+  onSubmit: (values: ClientFormValues) => void;
+}) => {
+  const [values, setValues] = useState<ClientFormValues>(() =>
+    mode === "edit" && client ? formFromClient(client) : emptyClientForm(),
+  );
+  const [errors, setErrors] = useState<ClientFormErrors>({});
+  const idPrefix = mode === "create" ? "create-client" : "edit-client";
+
+  useEffect(() => {
+    if (!open) return;
+    setValues(
+      mode === "edit" && client ? formFromClient(client) : emptyClientForm(),
+    );
+    setErrors({});
+  }, [client?.id, mode, open]);
+
+  const setValue = <K extends keyof ClientFormValues>(
+    key: K,
+    value: ClientFormValues[K],
+  ) => {
+    setValues((current) => ({ ...current, [key]: value }));
+  };
+
+  const updateUri = (
+    key: "redirectUris" | "logoutUris",
+    index: number,
+    value: string,
+  ) => {
+    setValues((current) => ({
+      ...current,
+      [key]: current[key].map((uri, uriIndex) =>
+        uriIndex === index ? value : uri,
+      ),
+    }));
+  };
+
+  const addUri = (key: "redirectUris" | "logoutUris") => {
+    setValues((current) => ({
+      ...current,
+      [key]: [...current[key], ""],
+    }));
+  };
+
+  const removeUri = (key: "redirectUris" | "logoutUris", index: number) => {
+    setValues((current) => ({
+      ...current,
+      [key]: current[key].filter((_, uriIndex) => uriIndex !== index),
+    }));
+  };
+
+  const toggleScope = (scope: string, checked: boolean) => {
+    setValues((current) => ({
+      ...current,
+      scopes: checked
+        ? current.scopes.includes(scope)
+          ? current.scopes
+          : [...current.scopes, scope]
+        : current.scopes.filter((value) => value !== scope),
+    }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors = validateClientForm(values, mode === "create");
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    setErrors({});
+    onSubmit(values);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? "Create OAuth client" : "Edit OAuth client"}
+          </DialogTitle>
+          <DialogDescription>
+            Register the application metadata and permissions used during OAuth
+            sign-in.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" noValidate onSubmit={handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-client-id`}>Client ID</Label>
+              <Input
+                id={`${idPrefix}-client-id`}
+                value={values.clientId}
+                onChange={(event) => setValue("clientId", event.target.value)}
+                disabled={mode === "edit"}
+                className={mode === "edit" ? "font-mono" : undefined}
+                autoComplete="off"
+              />
+              {mode === "create" && (
+                <p className="text-xs text-muted-foreground">
+                  3–64 characters: letters, digits, periods, underscores or
+                  hyphens.
+                </p>
+              )}
+              <FieldError message={errors.clientId} />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-name`}>Name</Label>
+              <Input
+                id={`${idPrefix}-name`}
+                value={values.name}
+                onChange={(event) => setValue("name", event.target.value)}
+                placeholder="NTHUMods mobile app"
+              />
+            </div>
+
+            <div className="space-y-2 sm:col-span-2">
+              <Label htmlFor={`${idPrefix}-client-uri`}>Client URI</Label>
+              <Input
+                id={`${idPrefix}-client-uri`}
+                type="url"
+                inputMode="url"
+                value={values.clientUri}
+                onChange={(event) => setValue("clientUri", event.target.value)}
+                placeholder="https://example.com"
+              />
+              <FieldError message={errors.clientUri} />
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="flex items-start gap-3 rounded-md border p-3">
+              <Switch
+                id={`${idPrefix}-first-party`}
+                checked={values.firstParty}
+                onCheckedChange={(checked) => setValue("firstParty", checked)}
+              />
+              <div className="space-y-1">
+                <Label htmlFor={`${idPrefix}-first-party`}>First-party</Label>
+                <p className="text-xs text-muted-foreground">
+                  Trusted NTHUMods-owned application. First-party clients cannot
+                  be deleted here.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3 rounded-md border p-3">
+              <Switch
+                id={`${idPrefix}-confidential`}
+                checked={values.confidential}
+                disabled={mode === "edit"}
+                onCheckedChange={(checked) => setValue("confidential", checked)}
+              />
+              <div className="space-y-1">
+                <Label htmlFor={`${idPrefix}-confidential`}>Confidential</Label>
+                <p className="text-xs text-muted-foreground">
+                  {mode === "edit"
+                    ? "Set at creation; use Rotate secret to replace its secret."
+                    : "Create a client secret for a server-side application."}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <UriListEditor
+            label="Redirect URIs"
+            description="Authorization codes may be sent only to these exact URLs."
+            values={values.redirectUris}
+            onChange={(index, value) => updateUri("redirectUris", index, value)}
+            onAdd={() => addUri("redirectUris")}
+            onRemove={(index) => removeUri("redirectUris", index)}
+            error={errors.redirectUris}
+            required
+            idPrefix={`${idPrefix}-redirect-uri`}
+          />
+
+          <UriListEditor
+            label="Logout URIs"
+            description="Optional URLs allowed as post-logout destinations."
+            values={values.logoutUris}
+            onChange={(index, value) => updateUri("logoutUris", index, value)}
+            onAdd={() => addUri("logoutUris")}
+            onRemove={(index) => removeUri("logoutUris", index)}
+            error={errors.logoutUris}
+            idPrefix={`${idPrefix}-logout-uri`}
+          />
+
+          <div className="space-y-2">
+            <div>
+              <Label>
+                Scopes <span className="text-destructive">*</span>
+              </Label>
+              <p className="mt-1 text-xs text-muted-foreground">
+                The authorization server will issue only the selected scopes.
+              </p>
+            </div>
+            <div
+              className="grid gap-2 sm:grid-cols-2"
+              role="group"
+              aria-label="OAuth scopes"
+            >
+              {VALID_SCOPES.map((scope) => (
+                <label
+                  key={scope.value}
+                  htmlFor={`${idPrefix}-scope-${scope.value}`}
+                  className="flex cursor-pointer items-start gap-3 rounded-md border p-3 hover:bg-muted/50"
+                >
+                  <Checkbox
+                    id={`${idPrefix}-scope-${scope.value}`}
+                    checked={values.scopes.includes(scope.value)}
+                    onCheckedChange={(checked) =>
+                      toggleScope(scope.value, checked === true)
+                    }
+                  />
+                  <span className="min-w-0">
+                    <span className="block font-mono text-sm">
+                      {scope.value}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      {scope.description}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+            <FieldError message={errors.scopes} />
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <DialogClose asChild>
+              <Button type="button" variant="outline">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={pending}>
+              {pending && <InlineSpinner />}
+              {mode === "create" ? "Create client" : "Save changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const SecretDialog = ({
+  notice,
+  onOpenChange,
+}: {
+  notice: SecretNotice | null;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { toast } = useToast();
+  const hasSecret = Boolean(notice?.clientSecret);
+
+  const copySecret = async () => {
+    if (!notice?.clientSecret) return;
+    try {
+      await navigator.clipboard.writeText(notice.clientSecret);
+      toast({ title: "Client secret copied" });
+    } catch {
+      toast({
+        title: "Could not copy client secret",
+        description: "Copy it manually before closing this dialog.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Dialog open={Boolean(notice)} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {notice?.action === "rotated"
+              ? "New client secret"
+              : "Client secret created"}
+          </DialogTitle>
+          <DialogDescription>
+            This secret is shown exactly once and will not be shown again after
+            this dialog is closed. Store it securely now.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="text-sm">
+            Client ID: <Mono>{notice?.clientId}</Mono>
+          </div>
+          {hasSecret ? (
+            <div className="rounded-md border bg-muted/50 p-3">
+              <code className="block break-all font-mono text-sm">
+                {notice?.clientSecret}
+              </code>
+            </div>
+          ) : (
+            <p className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground">
+              This is a public client and does not have a client secret.
+            </p>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            disabled={!hasSecret}
+            onClick={() => void copySecret()}
+          >
+            <Copy aria-hidden />
+            Copy secret
+          </Button>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button>{hasSecret ? "I saved the secret" : "Close"}</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const AdminClientsPage = () => {
+  const identity = useOutletContext<AdminIdentity>();
+  const query = useAdminOAuthClients();
+  const createMutation = useCreateOAuthClient();
+  const updateMutation = useUpdateOAuthClient();
+  const rotateMutation = useRotateClientSecret();
+  const deleteMutation = useDeleteOAuthClient();
+  const { toast } = useToast();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editClient, setEditClient] = useState<AdminClient | null>(null);
+  const [rotateClient, setRotateClient] = useState<AdminClient | null>(null);
+  const [deleteClient, setDeleteClient] = useState<AdminClient | null>(null);
+  const [secretNotice, setSecretNotice] = useState<SecretNotice | null>(null);
+  const [expandedClientId, setExpandedClientId] = useState<string | null>(null);
+
+  const showMutationError = (title: string, error: unknown) => {
+    toast({
+      title,
+      description: error instanceof Error ? error.message : "Something failed.",
+      variant: "destructive",
+    });
+  };
+
+  const handleCreate = (formValues: ClientFormValues) => {
+    createMutation.mutate(toApiInput(formValues), {
+      onSuccess: (client) => {
+        setCreateOpen(false);
+        setSecretNotice({
+          clientId: client.clientId,
+          clientSecret: client.clientSecret,
+          action: "created",
+        });
+      },
+      onError: (error) => showMutationError("Could not create client", error),
+    });
+  };
+
+  const handleUpdate = (formValues: ClientFormValues) => {
+    const { clientId, ...values } = toApiInput(formValues);
+    updateMutation.mutate(
+      { clientId, values },
+      {
+        onSuccess: () => {
+          setEditClient(null);
+          toast({ title: "OAuth client updated" });
+        },
+        onError: (error) => showMutationError("Could not update client", error),
+      },
+    );
+  };
+
+  const handleRotate = () => {
+    if (!rotateClient) return;
+    rotateMutation.mutate(rotateClient.clientId, {
+      onSuccess: (result) => {
+        setRotateClient(null);
+        setSecretNotice({
+          clientId: result.clientId,
+          clientSecret: result.clientSecret,
+          action: "rotated",
+        });
+      },
+      onError: (error) => showMutationError("Could not rotate secret", error),
+    });
+  };
+
+  const handleDelete = () => {
+    if (!deleteClient) return;
+    deleteMutation.mutate(deleteClient.clientId, {
+      onSuccess: () => {
+        setDeleteClient(null);
+        toast({ title: "OAuth client deleted" });
+      },
+      onError: (error) => showMutationError("Could not delete client", error),
+    });
+  };
+
+  if (!identity.isSuperuser) {
+    return (
+      <>
+        <PageHeader
+          title="OAuth Clients"
+          description="Applications registered with the NTHUMods authorization server."
+        />
+        <div className="flex items-start gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-4">
+          <ShieldAlert
+            className="mt-0.5 h-5 w-5 shrink-0 text-destructive"
+            aria-hidden
+          />
+          <div>
+            <h2 className="font-semibold">Superuser only</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              OAuth client registrations and secrets can be managed only by a
+              superuser.
+            </p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="OAuth Clients"
+        description="Applications registered with the NTHUMods authorization server."
+        actions={
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus aria-hidden />
+            New client
+          </Button>
+        }
+      />
+
+      {query.isError && <ErrorState error={query.error} />}
+
+      <TooltipProvider>
+        <div className="overflow-x-auto rounded-md border bg-background">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Client ID</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Scopes</TableHead>
+                <TableHead>Redirect URIs</TableHead>
+                <TableHead>Consents</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {query.isLoading &&
+                Array.from({ length: 5 }).map((_, index) => (
+                  <TableRow key={index}>
+                    <TableCell colSpan={7}>
+                      <div className="h-5 w-full animate-pulse rounded-md bg-muted" />
+                    </TableCell>
+                  </TableRow>
+                ))}
+
+              {query.data?.map((client) => {
+                const expanded = expandedClientId === client.clientId;
+                return (
+                  <Fragment key={client.id}>
+                    <TableRow>
+                      <TableCell className="align-top">
+                        <Mono>{client.clientId}</Mono>
+                      </TableCell>
+                      <TableCell className="max-w-[220px] align-top">
+                        <div className="truncate">
+                          {client.name || (
+                            <span className="text-muted-foreground">
+                              Unnamed
+                            </span>
+                          )}
+                        </div>
+                        {client.clientUri && (
+                          <div className="truncate text-xs text-muted-foreground">
+                            {client.clientUri}
+                          </div>
+                        )}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="flex min-w-[150px] flex-wrap gap-1">
+                          <Badge
+                            variant={client.firstParty ? "default" : "outline"}
+                          >
+                            {client.firstParty ? "First-party" : "Third-party"}
+                          </Badge>
+                          <Badge
+                            variant={
+                              client.confidential ? "secondary" : "outline"
+                            }
+                          >
+                            {client.confidential ? "Confidential" : "Public"}
+                          </Badge>
+                        </div>
+                      </TableCell>
+                      <TableCell className="max-w-[240px] align-top">
+                        <div className="flex min-w-[180px] flex-wrap gap-1">
+                          {client.scopes.map((scope) => (
+                            <Badge
+                              key={scope}
+                              variant="secondary"
+                              className="font-mono text-[0.7rem]"
+                            >
+                              {scope}
+                            </Badge>
+                          ))}
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="whitespace-nowrap px-2"
+                          aria-expanded={expanded}
+                          aria-label={`${expanded ? "Hide" : "Show"} redirect URIs for ${client.clientId}`}
+                          onClick={() =>
+                            setExpandedClientId(
+                              expanded ? null : client.clientId,
+                            )
+                          }
+                        >
+                          {client.redirectUris.length} URI
+                          {client.redirectUris.length === 1 ? "" : "s"}
+                          {expanded ? (
+                            <ChevronUp aria-hidden />
+                          ) : (
+                            <ChevronDown aria-hidden />
+                          )}
+                        </Button>
+                      </TableCell>
+                      <TableCell className="align-top tabular-nums">
+                        {client.consents.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="flex min-w-[260px] flex-wrap justify-end gap-1">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setEditClient(client)}
+                          >
+                            <Pencil aria-hidden />
+                            Edit
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setRotateClient(client)}
+                          >
+                            <RefreshCw aria-hidden />
+                            Rotate secret
+                          </Button>
+                          {client.firstParty ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span tabIndex={0}>
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    disabled
+                                  >
+                                    <Trash2 aria-hidden />
+                                    Delete
+                                  </Button>
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                First-party clients cannot be deleted.
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setDeleteClient(client)}
+                            >
+                              <Trash2 aria-hidden />
+                              Delete
+                            </Button>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                    {expanded && (
+                      <TableRow>
+                        <TableCell colSpan={7} className="bg-muted/20">
+                          <div className="space-y-3 py-1">
+                            <div>
+                              <div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Redirect URIs
+                              </div>
+                              <ul className="grid gap-1">
+                                {client.redirectUris.map((uri) => (
+                                  <li key={uri} className="break-all">
+                                    <Mono>{uri}</Mono>
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                            {client.logoutUris.length > 0 && (
+                              <div>
+                                <div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Logout URIs
+                                </div>
+                                <ul className="grid gap-1">
+                                  {client.logoutUris.map((uri) => (
+                                    <li key={uri} className="break-all">
+                                      <Mono>{uri}</Mono>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </TableBody>
+          </Table>
+
+          {!query.isLoading && query.data?.length === 0 && (
+            <EmptyState>No OAuth clients are registered.</EmptyState>
+          )}
+        </div>
+      </TooltipProvider>
+
+      <ClientFormDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        mode="create"
+        pending={createMutation.isPending}
+        onSubmit={handleCreate}
+      />
+      <ClientFormDialog
+        open={Boolean(editClient)}
+        onOpenChange={(open) => {
+          if (!open) setEditClient(null);
+        }}
+        mode="edit"
+        client={editClient ?? undefined}
+        pending={updateMutation.isPending}
+        onSubmit={handleUpdate}
+      />
+
+      <AlertDialog
+        open={Boolean(rotateClient)}
+        onOpenChange={(open) => {
+          if (!open && !rotateMutation.isPending) setRotateClient(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rotate client secret?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Every deployment still using the old secret will break when this
+              rotation completes. The new secret will be shown exactly once.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={rotateMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={rotateMutation.isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                handleRotate();
+              }}
+            >
+              {rotateMutation.isPending && <InlineSpinner />}
+              Rotate secret
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={Boolean(deleteClient)}
+        onOpenChange={(open) => {
+          if (!open && !deleteMutation.isPending) setDeleteClient(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete OAuth client?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes {deleteClient?.clientId} and its OAuth
+              registration. Existing tokens or consents for this client may no
+              longer work.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteMutation.isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                handleDelete();
+              }}
+            >
+              {deleteMutation.isPending && <InlineSpinner />}
+              Delete client
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <SecretDialog
+        notice={secretNotice}
+        onOpenChange={(open) => {
+          if (!open) setSecretNotice(null);
+        }}
+      />
+    </>
+  );
+};
 
 export default AdminClientsPage;

--- a/apps/web/src/app/[lang]/admin/components.tsx
+++ b/apps/web/src/app/[lang]/admin/components.tsx
@@ -1,0 +1,111 @@
+import { type ReactNode } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { Badge, Card, CardContent, Skeleton, cn } from "@courseweb/ui";
+import type { AdminRole } from "./api";
+
+/** Small shared pieces used across the admin center's pages. */
+
+export const PageHeader = ({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}) => (
+  <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+    <div>
+      <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+      {description && (
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      )}
+    </div>
+    {actions && <div className="flex items-center gap-2">{actions}</div>}
+  </div>
+);
+
+export const StatCard = ({
+  label,
+  value,
+  hint,
+  loading,
+}: {
+  label: string;
+  value: number | string | null | undefined;
+  hint?: string;
+  loading?: boolean;
+}) => (
+  <Card>
+    <CardContent className="p-4">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      {loading ? (
+        <Skeleton className="mt-2 h-8 w-20" />
+      ) : (
+        <div className="mt-1 text-2xl font-semibold tabular-nums">
+          {/* A null count means the source database could not be reached, which
+              is a different thing from a count of zero and has to read that way. */}
+          {value === null || value === undefined
+            ? "—"
+            : typeof value === "number"
+              ? value.toLocaleString()
+              : value}
+        </div>
+      )}
+      {hint && <div className="mt-1 text-xs text-muted-foreground">{hint}</div>}
+    </CardContent>
+  </Card>
+);
+
+export const RoleBadge = ({ role }: { role: AdminRole }) => {
+  if (role === "SUPERUSER") return <Badge>Superuser</Badge>;
+  if (role === "ADMIN") return <Badge variant="secondary">Admin</Badge>;
+  return <span className="text-xs text-muted-foreground">User</span>;
+};
+
+export const ErrorState = ({ error }: { error: unknown }) => (
+  <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+    <span>{error instanceof Error ? error.message : "Something failed."}</span>
+  </div>
+);
+
+export const EmptyState = ({ children }: { children: ReactNode }) => (
+  <div className="py-12 text-center text-sm text-muted-foreground">
+    {children}
+  </div>
+);
+
+export const InlineSpinner = ({ className }: { className?: string }) => (
+  <Loader2 className={cn("h-4 w-4 animate-spin", className)} aria-hidden />
+);
+
+/** Dates are shown in Taipei time — the only timezone the team operates in. */
+const formatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Taipei",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+export const formatDateTime = (value: string | null | undefined) =>
+  value ? formatter.format(new Date(value)) : "—";
+
+export const relativeTime = (value: string | null | undefined) => {
+  if (!value) return "—";
+  const diff = Date.now() - new Date(value).getTime();
+  const minutes = Math.round(diff / 60000);
+  if (Math.abs(minutes) < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+};
+
+export const Mono = ({ children }: { children: ReactNode }) => (
+  <span className="font-mono text-xs">{children}</span>
+);

--- a/apps/web/src/app/[lang]/admin/layout.tsx
+++ b/apps/web/src/app/[lang]/admin/layout.tsx
@@ -1,0 +1,178 @@
+import { NavLink, Outlet, useParams } from "react-router-dom";
+import { Suspense } from "react";
+import { useAuth } from "react-oidc-context";
+import { Badge, Button, cn } from "@courseweb/ui";
+import {
+  Activity,
+  ArrowLeft,
+  KeyRound,
+  Megaphone,
+  ScrollText,
+  ShieldAlert,
+  Users,
+} from "lucide-react";
+import { useAdminIdentity } from "./api";
+
+/**
+ * The admin center's shell.
+ *
+ * Deliberately not the student app's layout: no course sidebar, no bottom nav,
+ * no chat. Staff tools and student tools sharing a chrome is how someone ends
+ * up banning an account while thinking they are looking at their timetable.
+ */
+
+const NAV = [
+  { to: "", label: "Overview", icon: Activity, end: true },
+  { to: "users", label: "Users", icon: Users, end: false },
+  { to: "announcements", label: "Announcements", icon: Megaphone, end: false },
+  { to: "clients", label: "OAuth Clients", icon: KeyRound, superuser: true },
+  { to: "audit", label: "Audit Log", icon: ScrollText, end: false },
+] as const;
+
+const CenteredNotice = ({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}) => (
+  <div className="grid min-h-screen place-items-center px-6">
+    <div className="flex max-w-md flex-col items-center gap-3 text-center">
+      <ShieldAlert className="h-8 w-8 text-muted-foreground" aria-hidden />
+      <h1 className="text-xl font-semibold">{title}</h1>
+      <p className="text-sm text-muted-foreground">{description}</p>
+      {action}
+    </div>
+  </div>
+);
+
+const AdminLayout = () => {
+  const { lang } = useParams<{ lang: string }>();
+  const auth = useAuth();
+  const { data: identity, isLoading, isError } = useAdminIdentity();
+
+  const base = `/${lang === "en" ? "en" : "zh"}/admin`;
+
+  if (auth.isLoading || isLoading) {
+    return (
+      <CenteredNotice
+        title="Checking access"
+        description="Verifying your NTHUMods staff permissions."
+      />
+    );
+  }
+
+  if (!auth.isAuthenticated) {
+    return (
+      <CenteredNotice
+        title="Sign in required"
+        description="The admin center is only available to signed-in NTHUMods staff."
+        action={
+          <Button onClick={() => void auth.signinRedirect()}>
+            Sign in with NTHU
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (isError) {
+    return (
+      <CenteredNotice
+        title="Could not reach the auth server"
+        description="The admin API did not respond. Try again in a moment."
+      />
+    );
+  }
+
+  // A non-staff account is told the page does not exist rather than that it
+  // exists and is closed to them: the console's shape is not public knowledge.
+  if (!identity?.isAdmin) {
+    return (
+      <CenteredNotice
+        title="Page not found"
+        description="There is nothing here."
+        action={
+          <Button variant="outline" asChild>
+            <NavLink to={`/${lang === "en" ? "en" : "zh"}/today`}>
+              Back to NTHUMods
+            </NavLink>
+          </Button>
+        }
+      />
+    );
+  }
+
+  const visibleNav = NAV.filter(
+    (item) => !("superuser" in item && item.superuser) || identity.isSuperuser,
+  );
+
+  return (
+    <div className="min-h-screen bg-muted/30">
+      <header className="sticky top-0 z-20 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3">
+          <NavLink
+            to={`/${lang === "en" ? "en" : "zh"}/today`}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden />
+            <span className="hidden sm:inline">NTHUMods</span>
+          </NavLink>
+          <div className="flex items-center gap-2">
+            <span className="font-semibold tracking-tight">Admin Center</span>
+            <Badge variant={identity.isSuperuser ? "default" : "secondary"}>
+              {identity.role}
+            </Badge>
+          </div>
+          <div className="ml-auto min-w-0 text-right text-sm">
+            <div className="truncate font-medium">{identity.name}</div>
+            <div className="truncate font-mono text-xs text-muted-foreground">
+              {identity.userId}
+            </div>
+          </div>
+        </div>
+
+        <nav className="mx-auto max-w-7xl overflow-x-auto px-2">
+          <ul className="flex min-w-max items-center gap-1 pb-1">
+            {visibleNav.map((item) => {
+              const Icon = item.icon;
+              return (
+                <li key={item.to || "overview"}>
+                  <NavLink
+                    to={item.to ? `${base}/${item.to}` : base}
+                    end={item.to === ""}
+                    className={({ isActive }) =>
+                      cn(
+                        "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+                        isActive && "bg-muted text-foreground",
+                      )
+                    }
+                  >
+                    <Icon className="h-4 w-4" aria-hidden />
+                    {item.label}
+                  </NavLink>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-6">
+        <Suspense
+          fallback={
+            <div className="py-16 text-center text-sm text-muted-foreground">
+              Loading…
+            </div>
+          }
+        >
+          <Outlet context={identity} />
+        </Suspense>
+      </main>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/apps/web/src/app/[lang]/admin/page.tsx
+++ b/apps/web/src/app/[lang]/admin/page.tsx
@@ -1,0 +1,364 @@
+import { useState } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+} from "@courseweb/ui";
+import {
+  EmptyState,
+  ErrorState,
+  PageHeader,
+  StatCard,
+  formatDateTime,
+} from "./components";
+import { useAdminClientUsage, useAdminSignups, useAdminStats } from "./api";
+
+/**
+ * Overview.
+ *
+ * Two questions, in order: how many people are there, and is that number
+ * moving. Everything below the tiles exists to answer the second one.
+ */
+
+const RANGES = [
+  { value: "30", label: "Last 30 days" },
+  { value: "90", label: "Last 90 days" },
+  { value: "365", label: "Last year" },
+];
+
+const shortDay = (day: string) => day.slice(5).replace("-", "/");
+
+const ChartTooltip = ({
+  active,
+  payload,
+  valueLabel,
+  labelFormatter,
+}: {
+  active?: boolean;
+  payload?: { value?: number | string; payload?: Record<string, unknown> }[];
+  valueLabel: string;
+  labelFormatter: (raw: Record<string, unknown>) => string;
+}) => {
+  if (!active || !payload?.length) return null;
+  const row = payload[0];
+  return (
+    <div className="rounded-lg border bg-background p-2 text-sm shadow-sm">
+      <div className="text-[0.7rem] uppercase text-muted-foreground">
+        {labelFormatter(row.payload ?? {})}
+      </div>
+      <div className="font-semibold tabular-nums">
+        {row.value} <span className="font-normal">{valueLabel}</span>
+      </div>
+    </div>
+  );
+};
+
+const AdminOverviewPage = () => {
+  const [range, setRange] = useState("30");
+  const stats = useAdminStats();
+  const signups = useAdminSignups(Number(range));
+  const clientUsage = useAdminClientUsage();
+
+  const accounts = stats.data?.accounts;
+  const sessions = stats.data?.sessions;
+  const content = stats.data?.content;
+
+  return (
+    <>
+      <PageHeader
+        title="Overview"
+        description="Accounts, sessions and content across NTHUMods."
+      />
+
+      {stats.isError && <ErrorState error={stats.error} />}
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatCard
+          label="Accounts"
+          value={accounts?.total}
+          hint={
+            accounts
+              ? `+${accounts.new7d.toLocaleString()} this week`
+              : undefined
+          }
+          loading={stats.isLoading}
+        />
+        <StatCard
+          label="Active (30d)"
+          value={accounts?.active30d}
+          hint="Signed in at least once"
+          loading={stats.isLoading}
+        />
+        <StatCard
+          label="Live sessions"
+          value={sessions?.active}
+          hint={
+            sessions
+              ? `${sessions.refreshTokens.toLocaleString()} refresh tokens`
+              : undefined
+          }
+          loading={stats.isLoading}
+        />
+        <StatCard
+          label="Suspended"
+          value={accounts?.banned}
+          hint={accounts ? `${accounts.admins} staff accounts` : undefined}
+          loading={stats.isLoading}
+        />
+      </section>
+
+      <section className="mt-6 grid gap-4 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+            <CardTitle className="text-base">New accounts</CardTitle>
+            <Select value={range} onValueChange={setRange}>
+              <SelectTrigger className="w-[150px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RANGES.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </CardHeader>
+          <CardContent>
+            {signups.isLoading ? (
+              <Skeleton className="h-[240px] w-full" />
+            ) : signups.isError ? (
+              <ErrorState error={signups.error} />
+            ) : (
+              <div className="h-[240px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart
+                    data={signups.data?.series ?? []}
+                    margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+                  >
+                    <defs>
+                      <linearGradient
+                        id="signupFill"
+                        x1="0"
+                        y1="0"
+                        x2="0"
+                        y2="1"
+                      >
+                        <stop
+                          offset="0%"
+                          stopColor="hsl(var(--primary))"
+                          stopOpacity={0.28}
+                        />
+                        <stop
+                          offset="100%"
+                          stopColor="hsl(var(--primary))"
+                          stopOpacity={0}
+                        />
+                      </linearGradient>
+                    </defs>
+                    {/* Horizontal rules only: vertical ones compete with the
+                        single series for attention and add nothing here. */}
+                    <CartesianGrid
+                      vertical={false}
+                      stroke="hsl(var(--border))"
+                    />
+                    <XAxis
+                      dataKey="day"
+                      tickFormatter={shortDay}
+                      minTickGap={24}
+                      tickLine={false}
+                      axisLine={false}
+                      tick={{
+                        fontSize: 11,
+                        fill: "hsl(var(--muted-foreground))",
+                      }}
+                    />
+                    <YAxis
+                      allowDecimals={false}
+                      width={36}
+                      tickLine={false}
+                      axisLine={false}
+                      tick={{
+                        fontSize: 11,
+                        fill: "hsl(var(--muted-foreground))",
+                      }}
+                    />
+                    <Tooltip
+                      cursor={{ stroke: "hsl(var(--border))" }}
+                      content={(props) => (
+                        <ChartTooltip
+                          {...(props as never)}
+                          valueLabel="new accounts"
+                          labelFormatter={(row) =>
+                            formatDateTime(
+                              `${String(row.day)}T00:00:00Z`,
+                            ).slice(0, 10)
+                          }
+                        />
+                      )}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="count"
+                      stroke="hsl(var(--primary))"
+                      strokeWidth={2}
+                      fill="url(#signupFill)"
+                      activeDot={{ r: 4 }}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Tokens by client (30d)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {clientUsage.isLoading ? (
+              <Skeleton className="h-[240px] w-full" />
+            ) : clientUsage.isError ? (
+              <ErrorState error={clientUsage.error} />
+            ) : !clientUsage.data?.length ? (
+              <EmptyState>No tokens issued in the last 30 days.</EmptyState>
+            ) : (
+              <div className="h-[240px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    layout="vertical"
+                    data={clientUsage.data.slice(0, 6)}
+                    margin={{ top: 4, right: 40, left: 4, bottom: 4 }}
+                  >
+                    <XAxis type="number" hide />
+                    <YAxis
+                      type="category"
+                      dataKey="clientId"
+                      width={96}
+                      tickLine={false}
+                      axisLine={false}
+                      tick={{
+                        fontSize: 11,
+                        fill: "hsl(var(--muted-foreground))",
+                      }}
+                    />
+                    <Tooltip
+                      cursor={{ fill: "hsl(var(--muted))" }}
+                      content={(props) => (
+                        <ChartTooltip
+                          {...(props as never)}
+                          valueLabel="tokens"
+                          labelFormatter={(row) =>
+                            String(row.name ?? row.clientId ?? "")
+                          }
+                        />
+                      )}
+                    />
+                    <Bar dataKey="tokens" radius={[0, 4, 4, 0]} barSize={16}>
+                      {clientUsage.data.slice(0, 6).map((row) => (
+                        <Cell
+                          key={row.clientId}
+                          fill="hsl(var(--primary))"
+                          // First-party clients are the expected traffic; a
+                          // third party climbing this list is the signal.
+                          fillOpacity={row.firstParty ? 1 : 0.55}
+                        />
+                      ))}
+                      <LabelList
+                        dataKey="tokens"
+                        position="right"
+                        className="fill-muted-foreground"
+                        fontSize={11}
+                      />
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="mt-6 grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Credentials</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-3">
+            <StatCard
+              label="API keys"
+              value={sessions?.apiKeys}
+              loading={stats.isLoading}
+            />
+            <StatCard
+              label="Calendar links"
+              value={sessions?.calendarShareTokens}
+              loading={stats.isLoading}
+            />
+            <StatCard
+              label="OAuth clients"
+              value={stats.data?.oauth.clients}
+              loading={stats.isLoading}
+            />
+            <StatCard
+              label="Consents"
+              value={stats.data?.oauth.consents}
+              loading={stats.isLoading}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Content</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-3">
+            <StatCard
+              label="Courses"
+              value={content?.courses}
+              loading={stats.isLoading}
+            />
+            <StatCard
+              label="Course comments"
+              value={content?.comments}
+              loading={stats.isLoading}
+            />
+            <StatCard
+              label="Delay reports"
+              value={content?.delayReports}
+              loading={stats.isLoading}
+            />
+            <StatCard
+              label="Announcements"
+              value={content?.alerts}
+              loading={stats.isLoading}
+            />
+          </CardContent>
+        </Card>
+      </section>
+    </>
+  );
+};
+
+export default AdminOverviewPage;

--- a/apps/web/src/app/[lang]/admin/page.tsx
+++ b/apps/web/src/app/[lang]/admin/page.tsx
@@ -48,6 +48,16 @@ const RANGES = [
 
 const shortDay = (day: string) => day.slice(5).replace("-", "/");
 
+/**
+ * Recharts types its `content` render prop against its own internal payload
+ * shape, which changes between minor versions; this is the slice of it the
+ * tooltip below actually reads.
+ */
+type TooltipProps = {
+  active?: boolean;
+  payload?: { value?: number | string; payload?: Record<string, unknown> }[];
+};
+
 const ChartTooltip = ({
   active,
   payload,
@@ -205,9 +215,10 @@ const AdminOverviewPage = () => {
                     />
                     <Tooltip
                       cursor={{ stroke: "hsl(var(--border))" }}
-                      content={(props) => (
+                      content={(props: TooltipProps) => (
                         <ChartTooltip
-                          {...(props as never)}
+                          active={props.active}
+                          payload={props.payload}
                           valueLabel="new accounts"
                           labelFormatter={(row) =>
                             formatDateTime(
@@ -265,9 +276,10 @@ const AdminOverviewPage = () => {
                     />
                     <Tooltip
                       cursor={{ fill: "hsl(var(--muted))" }}
-                      content={(props) => (
+                      content={(props: TooltipProps) => (
                         <ChartTooltip
-                          {...(props as never)}
+                          active={props.active}
+                          payload={props.payload}
                           valueLabel="tokens"
                           labelFormatter={(row) =>
                             String(row.name ?? row.clientId ?? "")

--- a/apps/web/src/app/[lang]/admin/page.tsx
+++ b/apps/web/src/app/[lang]/admin/page.tsx
@@ -282,7 +282,11 @@ const AdminOverviewPage = () => {
                           payload={props.payload}
                           valueLabel="tokens"
                           labelFormatter={(row) =>
-                            String(row.name ?? row.clientId ?? "")
+                            typeof row.name === "string" && row.name
+                              ? row.name
+                              : typeof row.clientId === "string"
+                                ? row.clientId
+                                : ""
                           }
                         />
                       )}

--- a/apps/web/src/app/[lang]/admin/users/[userId]/page.tsx
+++ b/apps/web/src/app/[lang]/admin/users/[userId]/page.tsx
@@ -1,5 +1,793 @@
-import { PageHeader } from "../../components";
+import { useState } from "react";
+import { Link, useOutletContext, useParams } from "react-router-dom";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Textarea,
+  useToast,
+} from "@courseweb/ui";
+import { ArrowLeft } from "lucide-react";
+import {
+  EmptyState,
+  ErrorState,
+  InlineSpinner,
+  Mono,
+  PageHeader,
+  RoleBadge,
+  StatCard,
+  formatDateTime,
+  relativeTime,
+} from "../../components";
+import {
+  useAdminUser,
+  useRevokeUserSessions,
+  useSetUserBan,
+  useSetUserRole,
+  type AdminIdentity,
+  type AdminRole,
+  type AdminUserDetail,
+} from "../../api";
 
-const AdminUserDetailPage = () => <PageHeader title="User" />;
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : "Something failed.";
+
+const DateValue = ({
+  value,
+  withRelative = false,
+}: {
+  value: string | null | undefined;
+  withRelative?: boolean;
+}) => (
+  <div className="whitespace-nowrap">
+    <Mono>{formatDateTime(value)}</Mono>
+    {withRelative && value && (
+      <div className="text-xs text-muted-foreground">{relativeTime(value)}</div>
+    )}
+  </div>
+);
+
+const ScopeBadges = ({ scopes }: { scopes: string[] }) =>
+  scopes.length ? (
+    <div className="flex min-w-[150px] flex-wrap gap-1">
+      {scopes.map((scope, index) => (
+        <Badge
+          key={`${scope}-${index}`}
+          variant="outline"
+          className="px-1.5 py-0 text-[10px]"
+        >
+          {scope}
+        </Badge>
+      ))}
+    </div>
+  ) : (
+    <span className="text-xs text-muted-foreground">None</span>
+  );
+
+const UserDetailLoading = () => (
+  <div className="space-y-6">
+    <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {[
+        "Live tokens",
+        "API keys",
+        "Calendar share links",
+        "Consented clients",
+      ].map((label) => (
+        <StatCard key={label} label={label} value={undefined} loading />
+      ))}
+    </section>
+    <section className="space-y-6">
+      {[
+        "Sessions",
+        "Active tokens",
+        "API keys",
+        "Calendar share links",
+        "Consented clients",
+      ].map((title) => (
+        <Card key={title}>
+          <CardHeader>
+            <CardTitle className="text-base">{title}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-12 w-full" />
+          </CardContent>
+        </Card>
+      ))}
+    </section>
+  </div>
+);
+
+const SessionsCard = ({
+  sessions,
+}: {
+  sessions: AdminUserDetail["sessions"];
+}) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className="text-base">Sessions</CardTitle>
+    </CardHeader>
+    <CardContent className="p-0 sm:p-6 sm:pt-0">
+      {sessions.length === 0 ? (
+        <EmptyState>No sessions for this account.</EmptyState>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="min-w-[560px]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>State</TableHead>
+                <TableHead>Authenticated at</TableHead>
+                <TableHead>Expires</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sessions.map((session) => (
+                <TableRow key={session.id}>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        session.state.toUpperCase() === "ACTIVE"
+                          ? "default"
+                          : "secondary"
+                      }
+                    >
+                      {session.state}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={session.authenticatedAt} withRelative />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={session.expiresAt} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const TokensCard = ({ tokens }: { tokens: AdminUserDetail["tokens"] }) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className="text-base">Active tokens</CardTitle>
+    </CardHeader>
+    <CardContent className="p-0 sm:p-6 sm:pt-0">
+      {tokens.length === 0 ? (
+        <EmptyState>No active tokens for this account.</EmptyState>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="min-w-[720px]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Type</TableHead>
+                <TableHead>Client ID</TableHead>
+                <TableHead>Scopes</TableHead>
+                <TableHead>Expires</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {tokens.map((token) => (
+                <TableRow key={token.id}>
+                  <TableCell>
+                    <Badge variant="outline">{token.type}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <span className="break-all">
+                      <Mono>{token.clientId}</Mono>
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <ScopeBadges scopes={token.scopes} />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={token.expiresAt} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const ApiKeysCard = ({ apiKeys }: { apiKeys: AdminUserDetail["apiKeys"] }) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className="text-base">API keys</CardTitle>
+    </CardHeader>
+    <CardContent className="p-0 sm:p-6 sm:pt-0">
+      {apiKeys.length === 0 ? (
+        <EmptyState>No API keys for this account.</EmptyState>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="min-w-[900px]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Scopes</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead>State</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {apiKeys.map((apiKey) => (
+                <TableRow key={apiKey.id}>
+                  <TableCell className="max-w-[220px] break-words">
+                    {apiKey.name}
+                  </TableCell>
+                  <TableCell>
+                    <ScopeBadges scopes={apiKey.scopes} />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={apiKey.createdAt} />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={apiKey.lastUsedAt} withRelative />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={apiKey.expiresAt} />
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={apiKey.isRevoked ? "destructive" : "secondary"}
+                    >
+                      {apiKey.isRevoked ? "Revoked" : "Active"}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const ShareTokensCard = ({
+  shareTokens,
+}: {
+  shareTokens: AdminUserDetail["shareTokens"];
+}) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className="text-base">Calendar share links</CardTitle>
+    </CardHeader>
+    <CardContent className="p-0 sm:p-6 sm:pt-0">
+      {shareTokens.length === 0 ? (
+        <EmptyState>No calendar share links for this account.</EmptyState>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="min-w-[980px]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead>Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {shareTokens.map((shareToken) => (
+                <TableRow key={shareToken.id}>
+                  <TableCell className="max-w-[220px] break-words">
+                    {shareToken.name}
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={shareToken.createdAt} />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={shareToken.lastUsedAt} withRelative />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={shareToken.expiresAt} />
+                  </TableCell>
+                  <TableCell>
+                    <div className="space-y-1">
+                      <Badge
+                        variant={
+                          shareToken.revokedAt ? "destructive" : "secondary"
+                        }
+                      >
+                        {shareToken.revokedAt ? "Revoked" : "Active"}
+                      </Badge>
+                      {shareToken.revokedAt && (
+                        <div className="text-xs text-muted-foreground">
+                          {formatDateTime(shareToken.revokedAt)}
+                        </div>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        shareToken.includeFullDetails ? "default" : "outline"
+                      }
+                    >
+                      {shareToken.includeFullDetails
+                        ? "Full details"
+                        : "Busy/free only"}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const ConsentsCard = ({
+  consents,
+}: {
+  consents: AdminUserDetail["consents"];
+}) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className="text-base">Consented clients</CardTitle>
+    </CardHeader>
+    <CardContent className="p-0 sm:p-6 sm:pt-0">
+      {consents.length === 0 ? (
+        <EmptyState>No consented clients for this account.</EmptyState>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="min-w-[720px]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Client ID</TableHead>
+                <TableHead>Scopes</TableHead>
+                <TableHead>Granted at</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {consents.map((consent) => (
+                <TableRow key={consent.id}>
+                  <TableCell>
+                    <span className="break-all">
+                      <Mono>{consent.clientId}</Mono>
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <ScopeBadges scopes={consent.scopes} />
+                  </TableCell>
+                  <TableCell>
+                    <DateValue value={consent.grantedAt} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const UserActions = ({
+  userId,
+  user,
+  bootstrapSuperuser,
+  identity,
+}: {
+  userId: string;
+  user: AdminUserDetail["user"];
+  bootstrapSuperuser: boolean;
+  identity: AdminIdentity;
+}) => {
+  const { toast } = useToast();
+  const [selectedRole, setSelectedRole] = useState<AdminRole>(user.role);
+  const [roleDialogOpen, setRoleDialogOpen] = useState(false);
+  const [banDialogOpen, setBanDialogOpen] = useState(false);
+  const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
+  const [suspendReason, setSuspendReason] = useState("");
+
+  const roleMutation = useSetUserRole();
+  const banMutation = useSetUserBan();
+  const revokeMutation = useRevokeUserSessions();
+
+  const isOwnAccount = identity.userId === user.userId;
+  const roleDisabledReason = bootstrapSuperuser
+    ? "This account is the bootstrap superuser and cannot be demoted."
+    : isOwnAccount
+      ? "You cannot change your own role."
+      : undefined;
+  const roleUnchanged = selectedRole === user.role;
+  const roleActionDisabled =
+    Boolean(roleDisabledReason) || roleUnchanged || roleMutation.isPending;
+
+  const changeRole = async () => {
+    try {
+      await roleMutation.mutateAsync({ userId, role: selectedRole });
+      toast({
+        title: "Role updated",
+        description: `${user.name} is now ${selectedRole}.`,
+      });
+      setRoleDialogOpen(false);
+    } catch (error) {
+      toast({
+        title: "Could not change role",
+        description: errorMessage(error),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const changeBanState = async () => {
+    const banned = !user.banned;
+    try {
+      await banMutation.mutateAsync({
+        userId,
+        banned,
+        ...(banned && suspendReason.trim()
+          ? { reason: suspendReason.trim() }
+          : {}),
+      });
+      toast({
+        title: banned ? "Account suspended" : "Account restored",
+        description: banned
+          ? "Every token and session was deleted immediately."
+          : "The account can sign in again.",
+      });
+      setBanDialogOpen(false);
+      if (banned) setSuspendReason("");
+    } catch (error) {
+      toast({
+        title: banned
+          ? "Could not suspend account"
+          : "Could not restore account",
+        description: errorMessage(error),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const revokeSessions = async () => {
+    try {
+      const result = await revokeMutation.mutateAsync({ userId });
+      toast({
+        title: "Sessions revoked",
+        description: `${result.tokens} token${result.tokens === 1 ? "" : "s"} and ${result.sessions} session${result.sessions === 1 ? "" : "s"} deleted.`,
+      });
+      setRevokeDialogOpen(false);
+    } catch (error) {
+      toast({
+        title: "Could not revoke sessions",
+        description: errorMessage(error),
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Actions</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {identity.isSuperuser && (
+          <div className="space-y-3 border-b pb-6">
+            <div>
+              <h4 className="text-sm font-medium">Change role</h4>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Grant or remove staff access for this account.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Select
+                value={selectedRole}
+                onValueChange={(value) => setSelectedRole(value as AdminRole)}
+                disabled={Boolean(roleDisabledReason) || roleMutation.isPending}
+              >
+                <SelectTrigger className="w-[160px]" aria-label="New role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="USER">User</SelectItem>
+                  <SelectItem value="ADMIN">Admin</SelectItem>
+                  <SelectItem value="SUPERUSER">Superuser</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button
+                disabled={roleActionDisabled}
+                onClick={() => setRoleDialogOpen(true)}
+              >
+                {roleMutation.isPending && <InlineSpinner />}
+                Change role
+              </Button>
+            </div>
+            {roleDisabledReason ? (
+              <p className="text-xs text-muted-foreground">
+                {roleDisabledReason}
+              </p>
+            ) : (
+              roleUnchanged && (
+                <p className="text-xs text-muted-foreground">
+                  Select a different role to make a change.
+                </p>
+              )
+            )}
+
+            <AlertDialog
+              open={roleDialogOpen}
+              onOpenChange={(open) => {
+                if (!roleMutation.isPending) setRoleDialogOpen(open);
+              }}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Change this user&apos;s role?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will change {user.name}&apos;s role from {user.role} to{" "}
+                    {selectedRole}.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={roleMutation.isPending}>
+                    Cancel
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    disabled={roleMutation.isPending}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      void changeRole();
+                    }}
+                  >
+                    {roleMutation.isPending && <InlineSpinner />}
+                    Confirm role change
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h4 className="text-sm font-medium">
+              {user.banned ? "Restore account" : "Suspend account"}
+            </h4>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {user.banned
+                ? "Allow this account to sign in again."
+                : "Block sign-in and delete all credentials immediately."}
+            </p>
+          </div>
+          <Button
+            variant={user.banned ? "outline" : "destructive"}
+            disabled={banMutation.isPending}
+            onClick={() => setBanDialogOpen(true)}
+          >
+            {banMutation.isPending && <InlineSpinner />}
+            {user.banned ? "Restore account" : "Suspend account"}
+          </Button>
+        </div>
+
+        <AlertDialog
+          open={banDialogOpen}
+          onOpenChange={(open) => {
+            if (!banMutation.isPending) setBanDialogOpen(open);
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {user.banned
+                  ? "Restore this account?"
+                  : "Suspend this account?"}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {user.banned
+                  ? "The user will be allowed to sign in again."
+                  : "Suspending deletes every token and session immediately, and blocks this user from signing in."}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            {!user.banned && (
+              <div className="space-y-2">
+                <Label htmlFor="suspend-reason">Reason (optional)</Label>
+                <Textarea
+                  id="suspend-reason"
+                  value={suspendReason}
+                  onChange={(event) => setSuspendReason(event.target.value)}
+                  maxLength={500}
+                  placeholder="Explain why this account is being suspended."
+                />
+              </div>
+            )}
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={banMutation.isPending}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={banMutation.isPending}
+                className={
+                  user.banned
+                    ? undefined
+                    : "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                }
+                onClick={(event) => {
+                  event.preventDefault();
+                  void changeBanState();
+                }}
+              >
+                {banMutation.isPending && <InlineSpinner />}
+                {user.banned ? "Restore account" : "Suspend account"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h4 className="text-sm font-medium">Revoke sessions</h4>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Sign this user out everywhere without suspending the account.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            disabled={revokeMutation.isPending}
+            onClick={() => setRevokeDialogOpen(true)}
+          >
+            {revokeMutation.isPending && <InlineSpinner />}
+            Sign out everywhere
+          </Button>
+        </div>
+
+        <AlertDialog
+          open={revokeDialogOpen}
+          onOpenChange={(open) => {
+            if (!revokeMutation.isPending) setRevokeDialogOpen(open);
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                Sign this user out everywhere?
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                This deletes every token and session for {user.name}. The
+                account itself remains active.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={revokeMutation.isPending}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={revokeMutation.isPending}
+                onClick={(event) => {
+                  event.preventDefault();
+                  void revokeSessions();
+                }}
+              >
+                {revokeMutation.isPending && <InlineSpinner />}
+                Revoke sessions
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  );
+};
+
+const AdminUserDetailPage = () => {
+  const { lang, userId: routeUserId } = useParams<{
+    lang: string;
+    userId: string;
+  }>();
+  const userId = routeUserId ?? "";
+  const identity = useOutletContext<AdminIdentity>();
+  const query = useAdminUser(userId);
+  const detail = query.data;
+
+  return (
+    <>
+      <PageHeader
+        title={detail?.user.name ?? "User"}
+        description={detail?.user.nameEn}
+        actions={
+          <Button variant="outline" size="sm" asChild>
+            <Link to={`/${lang}/admin/users`}>
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Back to users
+            </Link>
+          </Button>
+        }
+      />
+
+      {query.isError && <ErrorState error={query.error} />}
+
+      {query.isLoading ? (
+        <UserDetailLoading />
+      ) : detail ? (
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+            <Mono>{detail.user.userId}</Mono>
+            <Mono>{detail.user.email}</Mono>
+            <span className="text-muted-foreground">
+              Joined <Mono>{formatDateTime(detail.user.createdAt)}</Mono>
+            </span>
+            <RoleBadge role={detail.user.role} />
+            {detail.user.banned && (
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="destructive">Suspended</Badge>
+                {detail.user.bannedReason && (
+                  <span className="max-w-full break-words text-xs text-destructive">
+                    Reason: {detail.user.bannedReason}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+
+          <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <StatCard label="Live tokens" value={detail.tokens.length} />
+            <StatCard label="API keys" value={detail.apiKeys.length} />
+            <StatCard
+              label="Calendar share links"
+              value={detail.shareTokens.length}
+            />
+            <StatCard
+              label="Consented clients"
+              value={detail.consents.length}
+            />
+          </section>
+
+          <section className="space-y-6">
+            <SessionsCard sessions={detail.sessions} />
+            <TokensCard tokens={detail.tokens} />
+            <ApiKeysCard apiKeys={detail.apiKeys} />
+            <ShareTokensCard shareTokens={detail.shareTokens} />
+            <ConsentsCard consents={detail.consents} />
+            <UserActions
+              userId={userId}
+              user={detail.user}
+              bootstrapSuperuser={detail.bootstrapSuperuser}
+              identity={identity}
+            />
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
+};
 
 export default AdminUserDetailPage;

--- a/apps/web/src/app/[lang]/admin/users/[userId]/page.tsx
+++ b/apps/web/src/app/[lang]/admin/users/[userId]/page.tsx
@@ -426,6 +426,14 @@ const UserActions = ({
     : isOwnAccount
       ? "You cannot change your own role."
       : undefined;
+  // The server already refuses a self-ban, but revoking your own sessions is a
+  // request it will happily carry out — signing the acting admin out of the
+  // page they are standing on. Both are closed here, where the reason can be
+  // shown before the click rather than as an error after it.
+  const selfActionReason = isOwnAccount
+    ? "This is your own account."
+    : undefined;
+
   const roleUnchanged = selectedRole === user.role;
   const roleActionDisabled =
     Boolean(roleDisabledReason) || roleUnchanged || roleMutation.isPending;
@@ -591,13 +599,18 @@ const UserActions = ({
           </div>
           <Button
             variant={user.banned ? "outline" : "destructive"}
-            disabled={banMutation.isPending}
+            disabled={banMutation.isPending || Boolean(selfActionReason)}
             onClick={() => setBanDialogOpen(true)}
           >
             {banMutation.isPending && <InlineSpinner />}
             {user.banned ? "Restore account" : "Suspend account"}
           </Button>
         </div>
+        {selfActionReason && (
+          <p className="-mt-2 text-xs text-muted-foreground">
+            {selfActionReason} You cannot suspend it or sign it out from here.
+          </p>
+        )}
 
         <AlertDialog
           open={banDialogOpen}
@@ -662,7 +675,7 @@ const UserActions = ({
           </div>
           <Button
             variant="outline"
-            disabled={revokeMutation.isPending}
+            disabled={revokeMutation.isPending || Boolean(selfActionReason)}
             onClick={() => setRevokeDialogOpen(true)}
           >
             {revokeMutation.isPending && <InlineSpinner />}

--- a/apps/web/src/app/[lang]/admin/users/[userId]/page.tsx
+++ b/apps/web/src/app/[lang]/admin/users/[userId]/page.tsx
@@ -1,0 +1,5 @@
+import { PageHeader } from "../../components";
+
+const AdminUserDetailPage = () => <PageHeader title="User" />;
+
+export default AdminUserDetailPage;

--- a/apps/web/src/app/[lang]/admin/users/page.tsx
+++ b/apps/web/src/app/[lang]/admin/users/page.tsx
@@ -1,0 +1,234 @@
+import { useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import { useDebounceValue } from "usehooks-ts";
+import {
+  Badge,
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@courseweb/ui";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+import {
+  EmptyState,
+  ErrorState,
+  Mono,
+  PageHeader,
+  RoleBadge,
+  formatDateTime,
+} from "../components";
+import { useAdminUsers, type AdminRole } from "../api";
+
+const PAGE_SIZE = 25;
+
+/**
+ * The user directory.
+ *
+ * Filters live in the URL so a maintainer can paste "every suspended account"
+ * into a thread instead of describing which three dropdowns to set.
+ */
+const AdminUsersPage = () => {
+  const { lang } = useParams<{ lang: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+  const role = (searchParams.get("role") ?? "all") as AdminRole | "all";
+  const banned = searchParams.get("banned") ?? "all";
+
+  const [searchInput, setSearchInput] = useState(searchParams.get("q") ?? "");
+  // Typing a student ID is nine keystrokes; querying on each one would be nine
+  // round trips to answer one question.
+  const [debouncedSearch] = useDebounceValue(searchInput, 300);
+
+  const query = useAdminUsers({
+    q: debouncedSearch.trim() || undefined,
+    role: role === "all" ? undefined : role,
+    banned: banned === "all" ? undefined : (banned as "true" | "false"),
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const updateParam = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value === "all" || value === "") next.delete(key);
+    else next.set(key, value);
+    // Any filter change invalidates the page number it was paired with.
+    if (key !== "page") next.delete("page");
+    setSearchParams(next, { replace: true });
+  };
+
+  const total = query.data?.total ?? 0;
+  const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <>
+      <PageHeader
+        title="Users"
+        description="Every account that has signed in through NTHUMods."
+      />
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[220px] flex-1">
+          <Search
+            className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <Input
+            className="pl-8"
+            placeholder="Student ID, name or email"
+            value={searchInput}
+            onChange={(event) => {
+              setSearchInput(event.target.value);
+              updateParam("q", event.target.value);
+            }}
+            aria-label="Search users"
+          />
+        </div>
+
+        <Select
+          value={role}
+          onValueChange={(value) => updateParam("role", value)}
+        >
+          <SelectTrigger className="w-[150px]" aria-label="Filter by role">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All roles</SelectItem>
+            <SelectItem value="USER">User</SelectItem>
+            <SelectItem value="ADMIN">Admin</SelectItem>
+            <SelectItem value="SUPERUSER">Superuser</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={banned}
+          onValueChange={(value) => updateParam("banned", value)}
+        >
+          <SelectTrigger className="w-[160px]" aria-label="Filter by status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="false">Active</SelectItem>
+            <SelectItem value="true">Suspended</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {query.isError && <ErrorState error={query.error} />}
+
+      <div className="overflow-x-auto rounded-md border bg-background">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[120px]">Student ID</TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead className="hidden md:table-cell">Email</TableHead>
+              <TableHead className="w-[110px]">Role</TableHead>
+              <TableHead className="w-[110px]">Status</TableHead>
+              <TableHead className="hidden lg:table-cell w-[150px]">
+                Joined
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {query.isLoading &&
+              Array.from({ length: 8 }).map((_, index) => (
+                <TableRow key={index}>
+                  <TableCell colSpan={6}>
+                    <Skeleton className="h-5 w-full" />
+                  </TableCell>
+                </TableRow>
+              ))}
+
+            {query.data?.users.map((user) => (
+              <TableRow key={user.id}>
+                <TableCell>
+                  <Link
+                    to={`/${lang}/admin/users/${user.userId}`}
+                    className="font-mono text-xs underline-offset-2 hover:underline"
+                  >
+                    {user.userId}
+                  </Link>
+                </TableCell>
+                <TableCell className="max-w-[220px]">
+                  <div className="truncate">{user.name}</div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {user.nameEn}
+                  </div>
+                </TableCell>
+                <TableCell className="hidden md:table-cell">
+                  <Mono>{user.email}</Mono>
+                </TableCell>
+                <TableCell>
+                  <RoleBadge role={user.role} />
+                </TableCell>
+                <TableCell>
+                  {user.banned ? (
+                    <Badge variant="destructive">Suspended</Badge>
+                  ) : user.inschool ? (
+                    <span className="text-xs text-muted-foreground">
+                      In school
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      Alumni
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="hidden lg:table-cell">
+                  <Mono>{formatDateTime(user.createdAt)}</Mono>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        {!query.isLoading && query.data?.users.length === 0 && (
+          <EmptyState>No accounts match those filters.</EmptyState>
+        )}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between text-sm text-muted-foreground">
+        <span>
+          {total.toLocaleString()} account{total === 1 ? "" : "s"}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => updateParam("page", String(page - 1))}
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+            Previous
+          </Button>
+          <span className="tabular-nums">
+            {page} / {lastPage}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= lastPage}
+            onClick={() => updateParam("page", String(page + 1))}
+          >
+            Next
+            <ChevronRight className="h-4 w-4" aria-hidden />
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AdminUsersPage;

--- a/apps/web/src/components/SideNav.tsx
+++ b/apps/web/src/components/SideNav.tsx
@@ -10,6 +10,7 @@ import {
   SidebarNavItemConfig,
   SidebarNavItemId,
 } from "@/app/[lang]/(mods-pages)/settings/SidebarNavSection";
+import { useAdminIdentity } from "@/app/[lang]/admin/api";
 
 const SideNav: FC = () => {
   const location = useLocation();
@@ -22,6 +23,10 @@ const SideNav: FC = () => {
     "sidebar_nav_items",
     DEFAULT_SIDEBAR_NAV_ITEMS,
   );
+  // Staff-only, and deliberately outside the configurable list above: the admin
+  // center is not something a student can turn on, so it has no business being
+  // a row in the sidebar settings everyone sees.
+  const { data: adminIdentity } = useAdminIdentity();
 
   const allLinks: Record<
     SidebarNavItemId,
@@ -82,6 +87,18 @@ const SideNav: FC = () => {
           <span className="flex-1 font-semibold">{link.title}</span>
         </div>
       ))}
+
+      {adminIdentity?.isAdmin && (
+        <div
+          className={`w-full flex flex-row items-center justify-start gap-2 rounded-md cursor-pointer transition font-semibold px-3 py-1.5 ${pathname.startsWith(`/${language}/admin`) ? "bg-primary text-primary-foreground" : "text-sidebar-foreground hover:bg-accent hover:text-accent-foreground"}`}
+          onClick={handleLinkClick(`/${language}/admin`)}
+        >
+          <span className="w-6 h-6">
+            <I.ShieldCheck strokeWidth="2" />
+          </span>
+          <span className="flex-1 font-semibold">Admin Center</span>
+        </div>
+      )}
     </nav>
   );
 };

--- a/apps/web/src/components/SideNav.tsx
+++ b/apps/web/src/components/SideNav.tsx
@@ -3,7 +3,7 @@ import { FC, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSettings } from "@/hooks/contexts/settings";
 import useDictionary from "@/dictionaries/useDictionary";
-import { useSidebar } from "@courseweb/ui";
+import { cn, useSidebar } from "@courseweb/ui";
 import { useLocalStorage } from "usehooks-ts";
 import {
   DEFAULT_SIDEBAR_NAV_ITEMS,
@@ -70,6 +70,9 @@ const SideNav: FC = () => {
     [navItems, allLinks],
   );
 
+  const adminHref = `/${language}/admin`;
+  const isAdminRoute = pathname.startsWith(adminHref);
+
   const handleLinkClick = (href: string) => () => {
     if (isMobile) setOpenMobile(false);
     navigate(href);
@@ -89,15 +92,23 @@ const SideNav: FC = () => {
       ))}
 
       {adminIdentity?.isAdmin && (
-        <div
-          className={`w-full flex flex-row items-center justify-start gap-2 rounded-md cursor-pointer transition font-semibold px-3 py-1.5 ${pathname.startsWith(`/${language}/admin`) ? "bg-primary text-primary-foreground" : "text-sidebar-foreground hover:bg-accent hover:text-accent-foreground"}`}
-          onClick={handleLinkClick(`/${language}/admin`)}
+        // A real button rather than the clickable div the rows above use: this
+        // one is new, and a div with an onClick is unreachable by keyboard.
+        <button
+          type="button"
+          className={cn(
+            "w-full flex flex-row items-center justify-start gap-2 rounded-md cursor-pointer transition font-semibold px-3 py-1.5",
+            isAdminRoute
+              ? "bg-primary text-primary-foreground"
+              : "text-sidebar-foreground hover:bg-accent hover:text-accent-foreground",
+          )}
+          onClick={handleLinkClick(adminHref)}
         >
           <span className="w-6 h-6">
             <I.ShieldCheck strokeWidth="2" />
           </span>
-          <span className="flex-1 font-semibold">Admin Center</span>
-        </div>
+          <span className="flex-1 text-left font-semibold">Admin Center</span>
+        </button>
       )}
     </nav>
   );

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -100,6 +100,19 @@ const GroupViewPage = lazy(
   () => import("@/app/[lang]/(mods-pages)/group/[code]/page"),
 );
 
+// Admin center (own layout, staff only)
+const AdminLayout = lazy(() => import("@/app/[lang]/admin/layout"));
+const AdminOverviewPage = lazy(() => import("@/app/[lang]/admin/page"));
+const AdminUsersPage = lazy(() => import("@/app/[lang]/admin/users/page"));
+const AdminUserDetailPage = lazy(
+  () => import("@/app/[lang]/admin/users/[userId]/page"),
+);
+const AdminAnnouncementsPage = lazy(
+  () => import("@/app/[lang]/admin/announcements/page"),
+);
+const AdminClientsPage = lazy(() => import("@/app/[lang]/admin/clients/page"));
+const AdminAuditPage = lazy(() => import("@/app/[lang]/admin/audit/page"));
+
 // Separate layout page
 const WaitlistPage = lazy(() => import("@/app/[lang]/waitlist/page"));
 
@@ -489,6 +502,25 @@ export const router = createBrowserRouter([
                 path: "*",
                 element: <NotFoundPage />,
               },
+            ],
+          },
+          {
+            path: "admin",
+            element: <AdminLayout />,
+            // The admin center is staff-only and gated at runtime; keeping it
+            // out of the index also keeps it out of search results.
+            handle: {
+              title: "Admin Center",
+              titleZh: "管理中心",
+              noindex: true,
+            },
+            children: [
+              { index: true, element: <AdminOverviewPage /> },
+              { path: "users", element: <AdminUsersPage /> },
+              { path: "users/:userId", element: <AdminUserDetailPage /> },
+              { path: "announcements", element: <AdminAnnouncementsPage /> },
+              { path: "clients", element: <AdminClientsPage /> },
+              { path: "audit", element: <AdminAuditPage /> },
             ],
           },
           {

--- a/docs/agent-reports/admin-announcements.md
+++ b/docs/agent-reports/admin-announcements.md
@@ -1,0 +1,41 @@
+# Admin announcements page
+
+## Built
+
+- Replaced the announcements placeholder with a responsive list of all announcements, including inactive drafts, severity/status badges, Taipei-localized windows, priority, dismissibility, edit actions, and AlertDialog-protected deletion.
+- Added create/edit dialog fields matching the secure API schema, client-side length/range/date/link validation, mutation error display in the dialog, and success/failure toasts.
+- Added explicit Asia/Taipei conversion between `datetime-local` values and offset-bearing API timestamps.
+- Added a live banner preview matching the public announcement renderer's severity styles, title/description layout, link behavior, and dismiss affordance.
+
+## Files touched
+
+- `apps/web/src/app/[lang]/admin/announcements/page.tsx`
+- `docs/agent-reports/admin-announcements.md`
+
+## Verification
+
+Typecheck command:
+
+```text
+cd apps/web && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep admin
+```
+
+Exact output:
+
+```text
+(no output)
+```
+
+Prettier check:
+
+```text
+bunx prettier --check apps/web/src/app/[lang]/admin/announcements/page.tsx
+Checking formatting...
+All matched files use Prettier code style!
+```
+
+`git diff --check` also passed. No other checks or changes were made.
+
+## Could not do
+
+Nothing outstanding.

--- a/docs/agent-reports/admin-api-tests.md
+++ b/docs/agent-reports/admin-api-tests.md
@@ -1,0 +1,44 @@
+# Admin API tests
+
+Added Bun coverage for the admin authorization middleware, user management API,
+and announcement validation. The tests cover role ranking and access gates,
+self-protection and bootstrap-superuser safeguards, administrator ban
+permissions, token/session revocation, unban reason clearing, user search and
+pagination, safe announcement links, and date ordering. The existing auth test
+now also verifies that a valid token for a banned account receives
+`account_suspended`.
+
+Files touched:
+
+- `services/secure-api/src/middleware/requireAdmin.test.ts` (new)
+- `services/secure-api/src/api/admin/users.test.ts` (new)
+- `services/secure-api/src/api/admin/announcements.test.ts` (new)
+- `services/secure-api/src/middleware/requireAuth.test.ts` (appended one test)
+- `docs/agent-reports/admin-api-tests.md` (this report)
+
+Verification:
+
+```text
+Command: cd services/secure-api && bun test src/middleware src/api/admin
+bun test v1.3.4 (5eb2145b)
+
+ 21 pass
+ 0 fail
+ 57 expect() calls
+Ran 21 tests across 4 files. [255.00ms]
+```
+
+```text
+Command: cd apps/web && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep admin
+Output: (empty)
+Pipeline exit status: 1 because grep found no matching lines.
+```
+
+```text
+Command: cd services/secure-api && bunx prettier --check src/middleware/requireAdmin.test.ts src/api/admin/users.test.ts src/api/admin/announcements.test.ts src/middleware/requireAuth.test.ts ../../docs/agent-reports/admin-api-tests.md
+Checking formatting...
+All matched files use Prettier code style!
+```
+
+Could not do: nothing. No implementation files were changed, and no commit or
+push was performed.

--- a/docs/agent-reports/admin-audit.md
+++ b/docs/agent-reports/admin-audit.md
@@ -1,0 +1,46 @@
+# Admin audit log
+
+## Built
+
+Implemented the staff audit log page with:
+
+- URL-backed action, actor ID, and page filters.
+- Debounced action searching and action-prefix shortcuts for `user.`,
+  `announcement.`, `client.`, and all actions.
+- Responsive paginated audit table with Taipei timestamps, relative times,
+  actor and user-target links, and destructive action badges.
+- Readable role-change, ban-reason, session-revoke, announcement, and client
+  metadata summaries, with expandable compact JSON for other metadata.
+
+## Files touched
+
+- `apps/web/src/app/[lang]/admin/audit/page.tsx`
+- `docs/agent-reports/admin-audit.md`
+
+## Verification
+
+Command:
+
+```text
+cd apps/web && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep admin
+```
+
+Output: empty. The pipeline returned exit code 1 because `grep` found no
+matching `admin` diagnostics.
+
+Command:
+
+```text
+bunx prettier --check apps/web/src/app/[lang]/admin/audit/page.tsx docs/agent-reports/admin-audit.md
+```
+
+Output:
+
+```text
+Checking formatting...
+All matched files use Prettier code style!
+```
+
+## Could not do
+
+Nothing blocking the requested implementation.

--- a/docs/agent-reports/admin-clients.md
+++ b/docs/agent-reports/admin-clients.md
@@ -1,0 +1,19 @@
+# Admin OAuth clients
+
+Built the superuser-only OAuth clients page for the admin center. It lists client metadata, scopes, consent counts, expandable redirect/logout URI details, and guarded edit, rotate-secret, and delete actions. Create and edit dialogs support repeatable URI fields, the seven server-approved scopes, client ID/URL/scope validation, and first-party/confidential settings. Secret creation and rotation show the returned secret once with a copy action and an explicit no-recovery warning.
+
+Files touched:
+
+- `apps/web/src/app/[lang]/admin/clients/page.tsx`
+- `apps/web/src/app/[lang]/admin/api.ts`
+- `docs/agent-reports/admin-clients.md`
+
+Verification:
+
+- Command: `cd apps/web && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep admin`
+  Output: no output.
+- Command: `bunx prettier --check 'apps/web/src/app/[lang]/admin/clients/page.tsx' 'apps/web/src/app/[lang]/admin/api.ts'`
+  Output: `Checking formatting...` followed by `All matched files use Prettier code style!`
+- `git diff --check` passed.
+
+Nothing else was changed, committed, or pushed. I did not run a browser or live API integration test.

--- a/docs/agent-reports/admin-user-detail.md
+++ b/docs/agent-reports/admin-user-detail.md
@@ -1,0 +1,44 @@
+# Admin user detail
+
+## Built
+
+- Replaced the user detail route placeholder with a responsive staff detail page.
+- Added the bilingual account header, account metadata, role/status badges, and four summary stat cards.
+- Added Sessions, Active tokens, API keys, Calendar share links, and Consented clients cards with responsive tables and explicit empty states.
+- Added guarded role changes for superusers, including bootstrap-superuser and self-account explanations, confirmation, pending spinners, and success/error toasts.
+- Added suspend/restore and sign-out-everywhere actions with AlertDialog confirmations, suspension reason input, immediate credential-deletion warning, pending spinners, and result toasts.
+- Used the existing typed admin hooks and shared admin components; no raw fetch calls or route changes were made.
+
+## Files touched
+
+- `apps/web/src/app/[lang]/admin/users/[userId]/page.tsx`
+- `docs/agent-reports/admin-user-detail.md`
+
+## Verification
+
+Command:
+
+```text
+cd apps/web && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep admin
+```
+
+Exact output: no output. The pipeline returned status 1 because `grep` found no admin diagnostics. The unfiltered compiler output contained only the known baseline errors in `shops/page.tsx`, `GenericIssueFormDialog.tsx`, `IssueFormDialog.tsx`, and `worker.ts`.
+
+Command:
+
+```text
+bunx prettier --check 'apps/web/src/app/[lang]/admin/users/[userId]/page.tsx'
+```
+
+Output:
+
+```text
+Checking formatting...
+All matched files use Prettier code style!
+```
+
+`git diff --check` passed for the page. No tests were run.
+
+## Could not do
+
+Nothing else was required or blocked.

--- a/services/secure-api/prisma/migrations/20260911120000_add_admin_roles/migration.sql
+++ b/services/secure-api/prisma/migrations/20260911120000_add_admin_roles/migration.sql
@@ -1,0 +1,33 @@
+-- Staff access for the admin center.
+CREATE TYPE "AdminRole" AS ENUM ('USER', 'ADMIN', 'SUPERUSER');
+
+ALTER TABLE "User"
+  ADD COLUMN "role" "AdminRole" NOT NULL DEFAULT 'USER',
+  ADD COLUMN "banned" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "bannedReason" TEXT;
+
+CREATE TABLE "AdminAuditLog" (
+    "id" TEXT NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "targetType" TEXT,
+    "targetId" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdminAuditLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AdminAuditLog_createdAt_idx" ON "AdminAuditLog"("createdAt");
+CREATE INDEX "AdminAuditLog_actorId_idx" ON "AdminAuditLog"("actorId");
+
+ALTER TABLE "AdminAuditLog"
+  ADD CONSTRAINT "AdminAuditLog_actorId_fkey"
+  FOREIGN KEY ("actorId") REFERENCES "User"("userId")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Bootstrap the first superuser. The account may not have logged in yet, in
+-- which case this updates nothing and src/const/admin.ts promotes it on its
+-- first sign-in instead. Both paths exist so neither ordering leaves the admin
+-- center with nobody who can let anyone else in.
+UPDATE "User" SET "role" = 'SUPERUSER' WHERE "userId" = '111060062';

--- a/services/secure-api/prisma/schema.prisma
+++ b/services/secure-api/prisma/schema.prisma
@@ -8,6 +8,15 @@ generator client {
   provider = "prisma-client-js"
 }
 
+// Staff access to the admin center. Deliberately separate from OAuth scopes:
+// scopes say what a *client application* may ask for on a user's behalf, this
+// says what the *person* is allowed to do inside NTHUMods itself.
+enum AdminRole {
+  USER
+  ADMIN
+  SUPERUSER
+}
+
 model User {
   id                  String               @id @default(uuid())
   userId              String               @unique
@@ -17,6 +26,9 @@ model User {
   inschool            Boolean
   cid                 String?
   lmsid               String?
+  role                AdminRole            @default(USER)
+  banned              Boolean              @default(false)
+  bannedReason        String?
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
   authSessions        AuthSessions[]
@@ -25,6 +37,24 @@ model User {
   apiKeys             ApiKey[]
   calendarShareTokens CalendarShareToken[]
   clientConsents      ClientConsent[]
+  adminActions        AdminAuditLog[]
+}
+
+// Every write an admin makes through the admin center lands here. Role changes
+// and bans are the kind of action that has to be attributable after the fact,
+// and the acting admin cannot edit or delete their own trail through the API.
+model AdminAuditLog {
+  id         String   @id @default(uuid())
+  actorId    String
+  action     String
+  targetType String?
+  targetId   String?
+  metadata   Json?
+  createdAt  DateTime @default(now())
+  actor      User     @relation(fields: [actorId], references: [userId], onDelete: Cascade)
+
+  @@index([createdAt])
+  @@index([actorId])
 }
 
 model AuthCode {

--- a/services/secure-api/src/api/admin/announcements.test.ts
+++ b/services/secure-api/src/api/admin/announcements.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { User } from "@prisma/client";
+import type { AdminEnv } from "./env";
+
+const supabaseFrom = mock();
+const supabaseInsert = mock();
+const supabaseSelect = mock();
+const supabaseSingle = mock();
+const recordAdminAction = mock(() => Promise.resolve());
+
+mock.module("../../config/supabase", () => ({
+  default: {
+    from: supabaseFrom,
+  },
+}));
+
+mock.module("../../utils/adminAudit", () => ({ recordAdminAction }));
+
+const { default: announcementsApp } = await import("./announcements");
+
+const makeUser = () =>
+  ({ userId: "admin-id", role: "ADMIN", banned: false }) as User;
+
+const requestAsAdmin = (body: unknown) => {
+  const app = new Hono<AdminEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", makeUser());
+    await next();
+  });
+  app.route("/", announcementsApp);
+  return app.request("/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+};
+
+const validBody = (link_url: string | undefined) => ({
+  title: "Scheduled maintenance",
+  description: "The service will be briefly unavailable.",
+  link_url,
+  severity: "info",
+  start_date: "2026-09-10T00:00:00+00:00",
+  end_date: "2026-09-11T00:00:00+00:00",
+  active: true,
+  dismissible: true,
+  priority: 0,
+});
+
+describe("admin announcements API", () => {
+  beforeEach(() => {
+    supabaseFrom.mockReset();
+    supabaseInsert.mockReset();
+    supabaseSelect.mockReset();
+    supabaseSingle.mockReset();
+    recordAdminAction.mockClear();
+
+    supabaseSingle.mockResolvedValue({
+      data: { id: 7 },
+      error: null,
+    });
+    supabaseSelect.mockReturnValue({ single: supabaseSingle });
+    supabaseInsert.mockReturnValue({ select: supabaseSelect });
+    supabaseFrom.mockReturnValue({ insert: supabaseInsert });
+  });
+
+  test("rejects javascript links before writing to Supabase", async () => {
+    const response = await requestAsAdmin(validBody("javascript:alert(1)"));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "invalid_request",
+      error_description: "link_url must be an in-app path or an http(s) URL",
+    });
+    expect(supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  test("accepts an in-app path", async () => {
+    const response = await requestAsAdmin(validBody("/recruit"));
+
+    expect(response.status).toBe(201);
+    expect(supabaseFrom).toHaveBeenCalledWith("alerts");
+    expect(supabaseInsert).toHaveBeenCalled();
+  });
+
+  test("accepts an https URL", async () => {
+    const response = await requestAsAdmin(validBody("https://example.com"));
+
+    expect(response.status).toBe(201);
+    expect(supabaseFrom).toHaveBeenCalledWith("alerts");
+    expect(supabaseInsert).toHaveBeenCalled();
+  });
+
+  test("rejects a start date after the end date before writing to Supabase", async () => {
+    const response = await requestAsAdmin({
+      ...validBody("/recruit"),
+      start_date: "2026-09-12T00:00:00+00:00",
+      end_date: "2026-09-11T00:00:00+00:00",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "invalid_request",
+      error_description: "start_date must fall before end_date",
+    });
+    expect(supabaseFrom).not.toHaveBeenCalled();
+  });
+});

--- a/services/secure-api/src/api/admin/announcements.ts
+++ b/services/secure-api/src/api/admin/announcements.ts
@@ -1,0 +1,204 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import supabase from "../../config/supabase";
+import { recordAdminAction } from "../../utils/adminAudit";
+import type { AdminEnv } from "./env";
+
+/**
+ * Announcements live in the public content database (`public.alerts`), not in
+ * the auth database, because the banner is read by every anonymous visitor.
+ * RLS there only exposes rows with `active = true`; this router holds the
+ * service role key, so drafts are visible here and nowhere else.
+ */
+
+const severity = z.enum(["info", "warning", "error"]);
+
+const announcementBody = z.object({
+  title: z.string().trim().min(1).max(200),
+  title_en: z.string().trim().max(200).nullish(),
+  description: z.string().trim().max(1000).nullish(),
+  description_en: z.string().trim().max(1000).nullish(),
+  link_url: z.string().trim().max(500).nullish(),
+  link_label: z.string().trim().max(100).nullish(),
+  link_label_en: z.string().trim().max(100).nullish(),
+  severity,
+  start_date: z.string().datetime({ offset: true }),
+  end_date: z.string().datetime({ offset: true }),
+  active: z.boolean().default(true),
+  dismissible: z.boolean().default(true),
+  priority: z.number().int().min(0).max(100).default(0),
+});
+
+/**
+ * A link is either an in-app path or a full URL. Anything else — `javascript:`
+ * above all — would be rendered straight into an anchor on a page every visitor
+ * sees, so it is rejected at the edge rather than sanitised at render time.
+ */
+const isAllowedLink = (link: string | null | undefined) => {
+  if (!link) return true;
+  if (link.startsWith("/")) return true;
+  try {
+    const url = new URL(link);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+const validateDates = (start: string, end: string) =>
+  new Date(start).getTime() < new Date(end).getTime();
+
+const app = new Hono<AdminEnv>()
+  // Every announcement, drafts included, newest window first.
+  .get("/", async (c) => {
+    const { data, error } = await supabase
+      .from("alerts")
+      .select("*")
+      .order("start_date", { ascending: false });
+
+    if (error) {
+      console.error("admin announcements: list failed", error.message);
+      return c.json({ error: "upstream_error" }, 502);
+    }
+
+    return c.json(data ?? []);
+  })
+
+  .post("/", zValidator("json", announcementBody), async (c) => {
+    const actor = c.get("user");
+    const body = c.req.valid("json");
+
+    if (!isAllowedLink(body.link_url)) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description:
+            "link_url must be an in-app path or an http(s) URL",
+        },
+        400,
+      );
+    }
+
+    if (!validateDates(body.start_date, body.end_date)) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "start_date must fall before end_date",
+        },
+        400,
+      );
+    }
+
+    const { data, error } = await supabase
+      .from("alerts")
+      .insert(body)
+      .select()
+      .single();
+
+    if (error) {
+      console.error("admin announcements: create failed", error.message);
+      return c.json({ error: "upstream_error" }, 502);
+    }
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "announcement.create",
+      targetType: "announcement",
+      targetId: String(data.id),
+      metadata: { title: body.title, active: body.active },
+    });
+
+    return c.json(data, 201);
+  })
+
+  .patch("/:id", zValidator("json", announcementBody.partial()), async (c) => {
+    const actor = c.get("user");
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id)) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    const body = c.req.valid("json");
+
+    if (!isAllowedLink(body.link_url)) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description:
+            "link_url must be an in-app path or an http(s) URL",
+        },
+        400,
+      );
+    }
+
+    if (
+      body.start_date &&
+      body.end_date &&
+      !validateDates(body.start_date, body.end_date)
+    ) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "start_date must fall before end_date",
+        },
+        400,
+      );
+    }
+
+    const { data, error } = await supabase
+      .from("alerts")
+      .update(body)
+      .eq("id", id)
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      console.error("admin announcements: update failed", error.message);
+      return c.json({ error: "upstream_error" }, 502);
+    }
+    if (!data) return c.json({ error: "not_found" }, 404);
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "announcement.update",
+      targetType: "announcement",
+      targetId: String(id),
+      metadata: { fields: Object.keys(body) },
+    });
+
+    return c.json(data);
+  })
+
+  .delete("/:id", async (c) => {
+    const actor = c.get("user");
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id)) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from("alerts")
+      .delete()
+      .eq("id", id)
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      console.error("admin announcements: delete failed", error.message);
+      return c.json({ error: "upstream_error" }, 502);
+    }
+    if (!data) return c.json({ error: "not_found" }, 404);
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "announcement.delete",
+      targetType: "announcement",
+      targetId: String(id),
+      metadata: { title: data.title },
+    });
+
+    return c.json({ deleted: true });
+  });
+
+export default app;

--- a/services/secure-api/src/api/admin/audit.ts
+++ b/services/secure-api/src/api/admin/audit.ts
@@ -1,0 +1,53 @@
+import { PrismaClient, type Prisma } from "@prisma/client";
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import type { AdminEnv } from "./env";
+
+const prisma = new PrismaClient();
+
+/**
+ * The admin audit trail, read-only on purpose.
+ *
+ * There is no delete or edit route here and there is not meant to be one: a
+ * trail an admin can rewrite answers no question worth asking.
+ */
+const app = new Hono<AdminEnv>().get(
+  "/",
+  zValidator(
+    "query",
+    z.object({
+      actorId: z.string().trim().max(50).optional(),
+      action: z.string().trim().max(100).optional(),
+      targetId: z.string().trim().max(100).optional(),
+      page: z.coerce.number().int().min(1).default(1),
+      pageSize: z.coerce.number().int().min(1).max(100).default(50),
+    }),
+  ),
+  async (c) => {
+    const { actorId, action, targetId, page, pageSize } = c.req.valid("query");
+
+    const where: Prisma.AdminAuditLogWhereInput = {
+      ...(actorId ? { actorId } : {}),
+      ...(action ? { action: { contains: action } } : {}),
+      ...(targetId ? { targetId } : {}),
+    };
+
+    const [total, entries] = await Promise.all([
+      prisma.adminAuditLog.count({ where }),
+      prisma.adminAuditLog.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        include: {
+          actor: { select: { userId: true, name: true, nameEn: true } },
+        },
+      }),
+    ]);
+
+    return c.json({ total, page, pageSize, entries });
+  },
+);
+
+export default app;

--- a/services/secure-api/src/api/admin/clients.ts
+++ b/services/secure-api/src/api/admin/clients.ts
@@ -1,0 +1,203 @@
+import { PrismaClient } from "@prisma/client";
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { recordAdminAction } from "../../utils/adminAudit";
+import { VALID_SCOPES } from "../../const/scopes";
+import type { AdminEnv } from "./env";
+
+const prisma = new PrismaClient();
+
+/**
+ * OAuth client registration.
+ *
+ * A registered client decides which redirect URIs can receive an authorization
+ * code, so a careless edit here is an account-takeover primitive. The whole
+ * router is SUPERUSER-only, and secrets are shown once at creation and never
+ * read back.
+ */
+
+const clientBody = z.object({
+  clientId: z
+    .string()
+    .trim()
+    .min(3)
+    .max(64)
+    .regex(/^[a-zA-Z0-9._-]+$/, "clientId may use letters, digits, . _ and -"),
+  name: z.string().trim().max(100).nullish(),
+  clientUri: z.string().trim().url().nullish(),
+  firstParty: z.boolean().default(false),
+  redirectUris: z.array(z.string().trim().url()).min(1).max(20),
+  logoutUris: z.array(z.string().trim().url()).max(20).default([]),
+  scopes: z.array(z.enum(VALID_SCOPES)).min(1),
+  confidential: z.boolean().default(false),
+});
+
+const publicFields = {
+  id: true,
+  clientId: true,
+  name: true,
+  clientUri: true,
+  firstParty: true,
+  redirectUris: true,
+  logoutUris: true,
+  scopes: true,
+} as const;
+
+const app = new Hono<AdminEnv>()
+  .use("*", requireAdmin("SUPERUSER"))
+
+  .get("/", async (c) => {
+    const [clients, consents] = await Promise.all([
+      prisma.client.findMany({
+        select: { ...publicFields, clientSecret: true },
+        orderBy: { clientId: "asc" },
+      }),
+      prisma.clientConsent.groupBy({
+        by: ["clientId"],
+        _count: { _all: true },
+      }),
+    ]);
+
+    const consentCounts = new Map(
+      consents.map((row) => [row.clientId, row._count._all]),
+    );
+
+    // The secret itself never leaves the server; whether one exists does, since
+    // that is what tells a maintainer if the client is confidential or public.
+    return c.json(
+      clients.map(({ clientSecret, ...client }) => ({
+        ...client,
+        confidential: Boolean(clientSecret),
+        consents: consentCounts.get(client.clientId) ?? 0,
+      })),
+    );
+  })
+
+  .post("/", zValidator("json", clientBody), async (c) => {
+    const actor = c.get("user");
+    const { confidential, ...body } = c.req.valid("json");
+
+    const existing = await prisma.client.findUnique({
+      where: { clientId: body.clientId },
+    });
+    if (existing) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "A client with that clientId already exists",
+        },
+        409,
+      );
+    }
+
+    const clientSecret = confidential
+      ? Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("hex")
+      : null;
+
+    const client = await prisma.client.create({
+      data: { ...body, clientSecret },
+      select: publicFields,
+    });
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "client.create",
+      targetType: "client",
+      targetId: body.clientId,
+      metadata: { firstParty: body.firstParty, confidential },
+    });
+
+    // The only time the secret is ever returned.
+    return c.json({ ...client, clientSecret }, 201);
+  })
+
+  .patch(
+    "/:clientId",
+    zValidator("json", clientBody.omit({ clientId: true }).partial()),
+    async (c) => {
+      const actor = c.get("user");
+      const clientId = c.req.param("clientId");
+      const { confidential, ...body } = c.req.valid("json");
+
+      const existing = await prisma.client.findUnique({ where: { clientId } });
+      if (!existing) return c.json({ error: "not_found" }, 404);
+
+      const client = await prisma.client.update({
+        where: { clientId },
+        data: body,
+        select: publicFields,
+      });
+
+      await recordAdminAction({
+        actorId: actor.userId,
+        action: "client.update",
+        targetType: "client",
+        targetId: clientId,
+        metadata: { fields: Object.keys(body) },
+      });
+
+      return c.json(client);
+    },
+  )
+
+  // Rotating invalidates every deployment still holding the old secret, so it
+  // is its own deliberate action rather than a side effect of an edit.
+  .post("/:clientId/rotate-secret", async (c) => {
+    const actor = c.get("user");
+    const clientId = c.req.param("clientId");
+
+    const existing = await prisma.client.findUnique({ where: { clientId } });
+    if (!existing) return c.json({ error: "not_found" }, 404);
+
+    const clientSecret = Buffer.from(
+      crypto.getRandomValues(new Uint8Array(32)),
+    ).toString("hex");
+
+    await prisma.client.update({ where: { clientId }, data: { clientSecret } });
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "client.rotate_secret",
+      targetType: "client",
+      targetId: clientId,
+    });
+
+    return c.json({ clientId, clientSecret });
+  })
+
+  .delete("/:clientId", async (c) => {
+    const actor = c.get("user");
+    const clientId = c.req.param("clientId");
+
+    const existing = await prisma.client.findUnique({ where: { clientId } });
+    if (!existing) return c.json({ error: "not_found" }, 404);
+
+    // Deleting the client the admin center itself signs in through would lock
+    // everyone out of the page they are standing on.
+    if (existing.firstParty) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description:
+            "First-party clients cannot be deleted from the admin center",
+        },
+        400,
+      );
+    }
+
+    await prisma.client.delete({ where: { clientId } });
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "client.delete",
+      targetType: "client",
+      targetId: clientId,
+      metadata: { name: existing.name ?? undefined },
+    });
+
+    return c.json({ deleted: true });
+  });
+
+export default app;

--- a/services/secure-api/src/api/admin/clients.ts
+++ b/services/secure-api/src/api/admin/clients.ts
@@ -18,6 +18,26 @@ const prisma = new PrismaClient();
  * read back.
  */
 
+/**
+ * What a client may be registered for.
+ *
+ * Two things are called a scope here. The consent scopes in VALID_SCOPES are
+ * what a user is asked to approve; `introspect:<clientId>` is machine-to-machine
+ * and is checked at /introspect, never shown to anyone. Both live in
+ * Client.scopes, so a registration form that only accepted the first would make
+ * the existing `nthumods-api` client uneditable without silently dropping the
+ * only scope it has.
+ */
+const clientScope = z.union([
+  z.enum(VALID_SCOPES),
+  z
+    .string()
+    .regex(
+      /^introspect:[A-Za-z0-9._-]{3,64}$/,
+      "introspect scopes are written introspect:<clientId>",
+    ),
+]);
+
 const clientBody = z.object({
   clientId: z
     .string()
@@ -30,7 +50,7 @@ const clientBody = z.object({
   firstParty: z.boolean().default(false),
   redirectUris: z.array(z.string().trim().url()).min(1).max(20),
   logoutUris: z.array(z.string().trim().url()).max(20).default([]),
-  scopes: z.array(z.enum(VALID_SCOPES)).min(1),
+  scopes: z.array(clientScope).min(1),
   confidential: z.boolean().default(false),
 });
 

--- a/services/secure-api/src/api/admin/env.ts
+++ b/services/secure-api/src/api/admin/env.ts
@@ -1,0 +1,14 @@
+import type { User } from "@prisma/client";
+
+/**
+ * Context shape inside the admin center's routers.
+ *
+ * `requireAuth` and `requireAdmin` are mounted once on the parent router, so
+ * the sub-routers never see the middleware that populates `user` and would
+ * otherwise have to reach for it untyped.
+ */
+export type AdminEnv = {
+  Variables: {
+    user: User;
+  };
+};

--- a/services/secure-api/src/api/admin/index.ts
+++ b/services/secure-api/src/api/admin/index.ts
@@ -1,0 +1,56 @@
+import { Hono } from "hono";
+import { requireAuth } from "../../middleware/requireAuth";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import type { AdminEnv } from "./env";
+import statsHandler from "./stats";
+import usersHandler from "./users";
+import announcementsHandler from "./announcements";
+import clientsHandler from "./clients";
+import auditHandler from "./audit";
+
+/**
+ * The NTHUMods admin center's API.
+ *
+ * Authenticated as a person through our own OIDC provider, then authorised on
+ * the account's role.
+ */
+
+/**
+ * Everything behind the staff gate.
+ *
+ * Kept as its own router rather than a `use()` placed after `/me`, so the gate
+ * does not depend on the reader knowing that Hono runs middleware in
+ * registration order. Nothing can be added to this router without going
+ * through requireAdmin.
+ */
+const gated = new Hono<AdminEnv>()
+  .use("*", requireAdmin("ADMIN"))
+  .route("/stats", statsHandler)
+  .route("/users", usersHandler)
+  .route("/announcements", announcementsHandler)
+  .route("/clients", clientsHandler)
+  .route("/audit", auditHandler);
+
+const app = new Hono<AdminEnv>()
+  .use("*", requireAuth())
+
+  // Deliberately outside the staff gate: the web app asks this to decide
+  // whether to show the admin center at all, and an ordinary 200 saying "you
+  // are not staff" is easier to reason about than a 403 from a route the
+  // caller was never meant to reach.
+  .get("/me", (c) => {
+    const user = c.get("user");
+    return c.json({
+      userId: user.userId,
+      name: user.name,
+      nameEn: user.nameEn,
+      email: user.email,
+      role: user.role,
+      isAdmin: user.role === "ADMIN" || user.role === "SUPERUSER",
+      isSuperuser: user.role === "SUPERUSER",
+    });
+  })
+
+  .route("/", gated);
+
+export default app;

--- a/services/secure-api/src/api/admin/stats.ts
+++ b/services/secure-api/src/api/admin/stats.ts
@@ -22,9 +22,13 @@ const startOfDaysAgo = (days: number) => {
  * unreachable table reports `null` and the UI shows a dash.
  */
 const countTable = async (table: string): Promise<number | null> => {
+  // `estimated` reads the planner's row estimate and falls back to an exact
+  // count only for small tables. An exact count of `courses` is a full scan of
+  // six figures of rows, which on its own took the whole overview past Bun's
+  // 10s idle timeout; a dashboard tile does not need the last digit.
   const { count, error } = await supabase
     .from(table)
-    .select("*", { count: "exact", head: true });
+    .select("*", { count: "estimated", head: true });
   if (error) {
     console.error(`admin stats: failed to count ${table}`, error.message);
     return null;
@@ -70,57 +74,53 @@ const app = new Hono<AdminEnv>()
     const last7 = startOfDaysAgo(7);
     const last30 = startOfDaysAgo(30);
 
-    const [
-      totalUsers,
-      newUsers7d,
-      newUsers30d,
-      bannedUsers,
-      admins,
-      activeSessions,
-      activeAccessTokens,
-      activeRefreshTokens,
-      activeApiKeys,
-      activeShareTokens,
-      clients,
-      consents,
-    ] = await Promise.all([
-      prisma.user.count(),
-      prisma.user.count({ where: { createdAt: { gte: last7 } } }),
-      prisma.user.count({ where: { createdAt: { gte: last30 } } }),
-      prisma.user.count({ where: { banned: true } }),
-      prisma.user.count({ where: { role: { in: ["ADMIN", "SUPERUSER"] } } }),
-      prisma.authSessions.count({
-        where: { state: "AUTHENTICATED", expiresAt: { gt: now } },
-      }),
-      prisma.token.count({ where: { type: "ACCESS", expiresAt: { gt: now } } }),
-      prisma.token.count({
-        where: { type: "REFRESH", expiresAt: { gt: now } },
-      }),
-      prisma.apiKey.count({ where: { isRevoked: false } }),
-      prisma.calendarShareToken.count({ where: { revokedAt: null } }),
-      prisma.client.count(),
-      prisma.clientConsent.count(),
-    ]);
+    // One round trip, not thirteen.
+    //
+    // DATABASE_URL goes through pgbouncer, which pins Prisma to a single
+    // connection, so a `Promise.all` of separate counts does not run in
+    // parallel — it queues. Thirteen queued counts against ap-southeast-1 took
+    // twelve seconds and tripped Bun's 10s idle timeout before this was one
+    // statement.
+    //
+    // COUNT(DISTINCT ...) on Token is likewise done here rather than through
+    // Prisma's `distinct`, which fetches every matching row to de-duplicate it
+    // in the application.
+    const [totals] = await prisma.$queryRaw<
+      {
+        total_users: bigint;
+        new_users_7d: bigint;
+        new_users_30d: bigint;
+        banned_users: bigint;
+        admins: bigint;
+        active_sessions: bigint;
+        access_tokens: bigint;
+        refresh_tokens: bigint;
+        api_keys: bigint;
+        share_tokens: bigint;
+        clients: bigint;
+        consents: bigint;
+        active_7d: bigint;
+        active_30d: bigint;
+      }[]
+    >`
+      SELECT
+        (SELECT COUNT(*) FROM "User") AS total_users,
+        (SELECT COUNT(*) FROM "User" WHERE "createdAt" >= ${last7}) AS new_users_7d,
+        (SELECT COUNT(*) FROM "User" WHERE "createdAt" >= ${last30}) AS new_users_30d,
+        (SELECT COUNT(*) FROM "User" WHERE "banned" IS TRUE) AS banned_users,
+        (SELECT COUNT(*) FROM "User" WHERE "role" <> 'USER') AS admins,
+        (SELECT COUNT(*) FROM "AuthSessions" WHERE "state" = 'AUTHENTICATED' AND "expiresAt" > ${now}) AS active_sessions,
+        (SELECT COUNT(*) FROM "Token" WHERE "type" = 'ACCESS' AND "expiresAt" > ${now}) AS access_tokens,
+        (SELECT COUNT(*) FROM "Token" WHERE "type" = 'REFRESH' AND "expiresAt" > ${now}) AS refresh_tokens,
+        (SELECT COUNT(*) FROM "ApiKey" WHERE "isRevoked" IS FALSE) AS api_keys,
+        (SELECT COUNT(*) FROM "CalendarShareToken" WHERE "revokedAt" IS NULL) AS share_tokens,
+        (SELECT COUNT(*) FROM "Client") AS clients,
+        (SELECT COUNT(*) FROM "ClientConsent") AS consents,
+        (SELECT COUNT(DISTINCT "userId") FROM "Token" WHERE "createdAt" >= ${last7}) AS active_7d,
+        (SELECT COUNT(DISTINCT "userId") FROM "Token" WHERE "createdAt" >= ${last30}) AS active_30d
+    `;
 
-    // "Active" here means a session that was used recently enough to be a fair
-    // proxy for a returning student; sessions live 180 days, so their bare
-    // count would only ever go up.
-    const [activeUsers7d, activeUsers30d] = await Promise.all([
-      prisma.token
-        .findMany({
-          where: { createdAt: { gte: last7 } },
-          distinct: ["userId"],
-          select: { userId: true },
-        })
-        .then((rows) => rows.length),
-      prisma.token
-        .findMany({
-          where: { createdAt: { gte: last30 } },
-          distinct: ["userId"],
-          select: { userId: true },
-        })
-        .then((rows) => rows.length),
-    ]);
+    const n = (value: bigint | undefined) => Number(value ?? 0);
 
     const [courses, comments, delayReports, alerts, contentUsers] =
       await Promise.all([
@@ -133,24 +133,24 @@ const app = new Hono<AdminEnv>()
 
     return c.json({
       accounts: {
-        total: totalUsers,
-        new7d: newUsers7d,
-        new30d: newUsers30d,
-        banned: bannedUsers,
-        admins,
-        active7d: activeUsers7d,
-        active30d: activeUsers30d,
+        total: n(totals?.total_users),
+        new7d: n(totals?.new_users_7d),
+        new30d: n(totals?.new_users_30d),
+        banned: n(totals?.banned_users),
+        admins: n(totals?.admins),
+        active7d: n(totals?.active_7d),
+        active30d: n(totals?.active_30d),
       },
       sessions: {
-        active: activeSessions,
-        accessTokens: activeAccessTokens,
-        refreshTokens: activeRefreshTokens,
-        apiKeys: activeApiKeys,
-        calendarShareTokens: activeShareTokens,
+        active: n(totals?.active_sessions),
+        accessTokens: n(totals?.access_tokens),
+        refreshTokens: n(totals?.refresh_tokens),
+        apiKeys: n(totals?.api_keys),
+        calendarShareTokens: n(totals?.share_tokens),
       },
       oauth: {
-        clients,
-        consents,
+        clients: n(totals?.clients),
+        consents: n(totals?.consents),
       },
       content: {
         courses,

--- a/services/secure-api/src/api/admin/stats.ts
+++ b/services/secure-api/src/api/admin/stats.ts
@@ -1,0 +1,208 @@
+import { PrismaClient } from "@prisma/client";
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import supabase from "../../config/supabase";
+import type { AdminEnv } from "./env";
+
+const prisma = new PrismaClient();
+
+const startOfDaysAgo = (days: number) => {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() - days);
+  return date;
+};
+
+/**
+ * Count rows in a Supabase table without transferring them.
+ *
+ * The content tables are in a different database from the auth tables, and a
+ * failing count there should not take the whole dashboard down with it: an
+ * unreachable table reports `null` and the UI shows a dash.
+ */
+const countTable = async (table: string): Promise<number | null> => {
+  const { count, error } = await supabase
+    .from(table)
+    .select("*", { count: "exact", head: true });
+  if (error) {
+    console.error(`admin stats: failed to count ${table}`, error.message);
+    return null;
+  }
+  return count ?? 0;
+};
+
+type DailyBucket = { day: string; count: number };
+
+/**
+ * Daily signup counts, zero-filled.
+ *
+ * `date_trunc` only emits days that actually have rows, which draws a chart
+ * where a quiet Sunday silently becomes a straight line between Saturday and
+ * Monday instead of a dip to zero.
+ */
+const signupSeries = async (days: number): Promise<DailyBucket[]> => {
+  const since = startOfDaysAgo(days - 1);
+  const rows = await prisma.$queryRaw<{ day: Date; count: bigint }[]>`
+    SELECT date_trunc('day', "createdAt") AS day, COUNT(*)::bigint AS count
+    FROM "User"
+    WHERE "createdAt" >= ${since}
+    GROUP BY 1
+    ORDER BY 1 ASC
+  `;
+
+  const counts = new Map(
+    rows.map((row) => [row.day.toISOString().slice(0, 10), Number(row.count)]),
+  );
+
+  const series: DailyBucket[] = [];
+  for (let offset = days - 1; offset >= 0; offset--) {
+    const day = startOfDaysAgo(offset).toISOString().slice(0, 10);
+    series.push({ day, count: counts.get(day) ?? 0 });
+  }
+  return series;
+};
+
+const app = new Hono<AdminEnv>()
+  // Headline numbers for the admin overview.
+  .get("/", async (c) => {
+    const now = new Date();
+    const last7 = startOfDaysAgo(7);
+    const last30 = startOfDaysAgo(30);
+
+    const [
+      totalUsers,
+      newUsers7d,
+      newUsers30d,
+      bannedUsers,
+      admins,
+      activeSessions,
+      activeAccessTokens,
+      activeRefreshTokens,
+      activeApiKeys,
+      activeShareTokens,
+      clients,
+      consents,
+    ] = await Promise.all([
+      prisma.user.count(),
+      prisma.user.count({ where: { createdAt: { gte: last7 } } }),
+      prisma.user.count({ where: { createdAt: { gte: last30 } } }),
+      prisma.user.count({ where: { banned: true } }),
+      prisma.user.count({ where: { role: { in: ["ADMIN", "SUPERUSER"] } } }),
+      prisma.authSessions.count({
+        where: { state: "AUTHENTICATED", expiresAt: { gt: now } },
+      }),
+      prisma.token.count({ where: { type: "ACCESS", expiresAt: { gt: now } } }),
+      prisma.token.count({
+        where: { type: "REFRESH", expiresAt: { gt: now } },
+      }),
+      prisma.apiKey.count({ where: { isRevoked: false } }),
+      prisma.calendarShareToken.count({ where: { revokedAt: null } }),
+      prisma.client.count(),
+      prisma.clientConsent.count(),
+    ]);
+
+    // "Active" here means a session that was used recently enough to be a fair
+    // proxy for a returning student; sessions live 180 days, so their bare
+    // count would only ever go up.
+    const [activeUsers7d, activeUsers30d] = await Promise.all([
+      prisma.token
+        .findMany({
+          where: { createdAt: { gte: last7 } },
+          distinct: ["userId"],
+          select: { userId: true },
+        })
+        .then((rows) => rows.length),
+      prisma.token
+        .findMany({
+          where: { createdAt: { gte: last30 } },
+          distinct: ["userId"],
+          select: { userId: true },
+        })
+        .then((rows) => rows.length),
+    ]);
+
+    const [courses, comments, delayReports, alerts, contentUsers] =
+      await Promise.all([
+        countTable("courses"),
+        countTable("course_comments"),
+        countTable("delay_reports"),
+        countTable("alerts"),
+        countTable("users"),
+      ]);
+
+    return c.json({
+      accounts: {
+        total: totalUsers,
+        new7d: newUsers7d,
+        new30d: newUsers30d,
+        banned: bannedUsers,
+        admins,
+        active7d: activeUsers7d,
+        active30d: activeUsers30d,
+      },
+      sessions: {
+        active: activeSessions,
+        accessTokens: activeAccessTokens,
+        refreshTokens: activeRefreshTokens,
+        apiKeys: activeApiKeys,
+        calendarShareTokens: activeShareTokens,
+      },
+      oauth: {
+        clients,
+        consents,
+      },
+      content: {
+        courses,
+        comments,
+        delayReports,
+        alerts,
+        contentUsers,
+      },
+    });
+  })
+
+  // Signup trend for the overview chart.
+  .get(
+    "/signups",
+    zValidator(
+      "query",
+      z.object({
+        days: z.coerce.number().int().min(7).max(365).default(30),
+      }),
+    ),
+    async (c) => {
+      const { days } = c.req.valid("query");
+      return c.json({ days, series: await signupSeries(days) });
+    },
+  )
+
+  // Which OAuth clients traffic is actually coming through.
+  .get("/clients", async (c) => {
+    const since = startOfDaysAgo(30);
+    const [grouped, clients] = await Promise.all([
+      prisma.token.groupBy({
+        by: ["clientId"],
+        where: { createdAt: { gte: since } },
+        _count: { _all: true },
+      }),
+      prisma.client.findMany({
+        select: { clientId: true, name: true, firstParty: true },
+      }),
+    ]);
+
+    const names = new Map(clients.map((client) => [client.clientId, client]));
+
+    return c.json(
+      grouped
+        .map((row) => ({
+          clientId: row.clientId,
+          name: names.get(row.clientId)?.name ?? null,
+          firstParty: names.get(row.clientId)?.firstParty ?? false,
+          tokens: row._count._all,
+        }))
+        .sort((a, b) => b.tokens - a.tokens),
+    );
+  });
+
+export default app;

--- a/services/secure-api/src/api/admin/users.test.ts
+++ b/services/secure-api/src/api/admin/users.test.ts
@@ -238,4 +238,38 @@ describe("admin users API", () => {
       }),
     );
   });
+
+  test("refuses to revoke the acting admin's own sessions", async () => {
+    const actor = makeUser({ userId: "admin-id", role: "ADMIN" });
+
+    const response = await requestAs(actor, "/admin-id/sessions", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(400);
+    // Nothing is deleted, so the admin is still signed in to act on whatever
+    // brought them here.
+    expect(tokenDeleteMany).not.toHaveBeenCalled();
+    expect(authSessionsDeleteMany).not.toHaveBeenCalled();
+  });
+
+  test("revokes another account's sessions and tokens", async () => {
+    const actor = makeUser({ userId: "admin-id", role: "ADMIN" });
+    userFindUnique.mockResolvedValueOnce(makeUser({ userId: "target-id" }));
+    tokenDeleteMany.mockResolvedValueOnce({ count: 4 });
+    authSessionsDeleteMany.mockResolvedValueOnce({ count: 2 });
+
+    const response = await requestAs(actor, "/target-id/sessions", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ tokens: 4, sessions: 2 });
+    expect(tokenDeleteMany).toHaveBeenCalledWith({
+      where: { userId: "target-id" },
+    });
+    expect(authSessionsDeleteMany).toHaveBeenCalledWith({
+      where: { userId: "target-id" },
+    });
+  });
 });

--- a/services/secure-api/src/api/admin/users.test.ts
+++ b/services/secure-api/src/api/admin/users.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AdminRole, User } from "@prisma/client";
+import type { AdminEnv } from "./env";
+
+const userFindUnique = mock();
+const userFindMany = mock();
+const userCount = mock();
+const userUpdate = mock();
+const tokenDeleteMany = mock();
+const authSessionsDeleteMany = mock();
+const adminAuditCreate = mock();
+
+mock.module("@prisma/client", () => ({
+  PrismaClient: class {
+    user = {
+      findUnique: userFindUnique,
+      findMany: userFindMany,
+      count: userCount,
+      update: userUpdate,
+    };
+    token = {
+      deleteMany: tokenDeleteMany,
+    };
+    authSessions = {
+      deleteMany: authSessionsDeleteMany,
+    };
+    adminAuditLog = {
+      create: adminAuditCreate,
+    };
+  },
+}));
+
+const { default: usersApp } = await import("./users");
+
+const jsonHeaders = { "Content-Type": "application/json" };
+
+const makeUser = (overrides: Partial<User> = {}) =>
+  ({
+    id: "user-row-id",
+    userId: "user-id",
+    name: "Test User",
+    nameEn: "Test User",
+    email: "test@example.com",
+    inschool: true,
+    cid: null,
+    lmsid: null,
+    role: "USER" as AdminRole,
+    banned: false,
+    bannedReason: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  }) as User;
+
+const requestAs = (actor: User, path: string, init?: RequestInit) => {
+  const app = new Hono<AdminEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", actor);
+    await next();
+  });
+  app.route("/", usersApp);
+  return app.request(path, init);
+};
+
+const patchJson = (body: unknown): RequestInit => ({
+  method: "PATCH",
+  headers: jsonHeaders,
+  body: JSON.stringify(body),
+});
+
+describe("admin users API", () => {
+  beforeEach(() => {
+    userFindUnique.mockReset();
+    userFindMany.mockReset();
+    userCount.mockReset();
+    userUpdate.mockReset();
+    tokenDeleteMany.mockReset();
+    authSessionsDeleteMany.mockReset();
+    adminAuditCreate.mockReset();
+  });
+
+  test("refuses changing your own role", async () => {
+    const actor = makeUser({ userId: "actor-id", role: "SUPERUSER" });
+    const response = await requestAs(
+      actor,
+      "/actor-id/role",
+      patchJson({ role: "ADMIN" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "invalid_request",
+      error_description: "You cannot change your own role",
+    });
+    expect(userFindUnique).not.toHaveBeenCalled();
+  });
+
+  test("refuses demoting a bootstrap superuser", async () => {
+    const actor = makeUser({ userId: "actor-id", role: "SUPERUSER" });
+    const response = await requestAs(
+      actor,
+      "/111060062/role",
+      patchJson({ role: "ADMIN" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "invalid_request",
+      error_description:
+        "This account is a bootstrap superuser and cannot be demoted",
+    });
+    expect(userFindUnique).not.toHaveBeenCalled();
+  });
+
+  test("refuses banning yourself", async () => {
+    const actor = makeUser({ userId: "actor-id", role: "ADMIN" });
+    const response = await requestAs(
+      actor,
+      "/actor-id/ban",
+      patchJson({ banned: true, reason: "testing" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "invalid_request",
+      error_description: "You cannot ban yourself",
+    });
+    expect(userFindUnique).not.toHaveBeenCalled();
+  });
+
+  test("prevents an admin from banning another admin", async () => {
+    const actor = makeUser({ userId: "actor-id", role: "ADMIN" });
+    userFindUnique.mockResolvedValueOnce(
+      makeUser({ userId: "target-id", role: "ADMIN" }),
+    );
+
+    const response = await requestAs(
+      actor,
+      "/target-id/ban",
+      patchJson({ banned: true }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "forbidden",
+      error_description: "Only a superuser can suspend an administrator",
+    });
+    expect(userUpdate).not.toHaveBeenCalled();
+    expect(tokenDeleteMany).not.toHaveBeenCalled();
+    expect(authSessionsDeleteMany).not.toHaveBeenCalled();
+  });
+
+  test("allows a superuser to ban an admin and revoke both sessions and tokens", async () => {
+    const actor = makeUser({ userId: "actor-id", role: "SUPERUSER" });
+    userFindUnique.mockResolvedValueOnce(
+      makeUser({ userId: "target-id", role: "ADMIN" }),
+    );
+    userUpdate.mockResolvedValueOnce(
+      makeUser({
+        userId: "target-id",
+        role: "ADMIN",
+        banned: true,
+        bannedReason: "policy violation",
+      }),
+    );
+    tokenDeleteMany.mockResolvedValueOnce({ count: 2 });
+    authSessionsDeleteMany.mockResolvedValueOnce({ count: 1 });
+
+    const response = await requestAs(
+      actor,
+      "/target-id/ban",
+      patchJson({ banned: true, reason: "policy violation" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(tokenDeleteMany).toHaveBeenCalledWith({
+      where: { userId: "target-id" },
+    });
+    expect(authSessionsDeleteMany).toHaveBeenCalledWith({
+      where: { userId: "target-id" },
+    });
+  });
+
+  test("unban clears the banned reason", async () => {
+    const actor = makeUser({ userId: "actor-id", role: "ADMIN" });
+    userFindUnique.mockResolvedValueOnce(
+      makeUser({
+        userId: "target-id",
+        banned: true,
+        bannedReason: "temporary",
+      }),
+    );
+    userUpdate.mockResolvedValueOnce(
+      makeUser({ userId: "target-id", banned: false, bannedReason: null }),
+    );
+
+    const response = await requestAs(
+      actor,
+      "/target-id/ban",
+      patchJson({ banned: false }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(userUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "target-id" },
+        data: { banned: false, bannedReason: null },
+      }),
+    );
+    expect(tokenDeleteMany).not.toHaveBeenCalled();
+    expect(authSessionsDeleteMany).not.toHaveBeenCalled();
+  });
+
+  test("searches all user identity fields and paginates the result", async () => {
+    const actor = makeUser({ userId: "actor-id", role: "ADMIN" });
+    userCount.mockResolvedValueOnce(41);
+    userFindMany.mockResolvedValueOnce([]);
+
+    const response = await requestAs(actor, "/?q=alice&page=3&pageSize=10");
+
+    expect(response.status).toBe(200);
+
+    const expectedWhere = {
+      OR: [
+        { userId: { contains: "alice", mode: "insensitive" } },
+        { name: { contains: "alice", mode: "insensitive" } },
+        { nameEn: { contains: "alice", mode: "insensitive" } },
+        { email: { contains: "alice", mode: "insensitive" } },
+      ],
+    };
+    expect(userCount).toHaveBeenCalledWith({ where: expectedWhere });
+    expect(userFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expectedWhere,
+        skip: 20,
+        take: 10,
+      }),
+    );
+  });
+});

--- a/services/secure-api/src/api/admin/users.ts
+++ b/services/secure-api/src/api/admin/users.ts
@@ -282,6 +282,20 @@ const app = new Hono<AdminEnv>()
     const actor = c.get("user");
     const userId = c.req.param("userId");
 
+    // Revoking your own sessions from here would sign you out of the admin
+    // center mid-action. Signing yourself out is a thing you do from your own
+    // settings, where it is what you meant.
+    if (userId === actor.userId) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description:
+            "Use your own account settings to sign yourself out",
+        },
+        400,
+      );
+    }
+
     const existing = await prisma.user.findUnique({ where: { userId } });
     if (!existing) return c.json({ error: "not_found" }, 404);
 

--- a/services/secure-api/src/api/admin/users.ts
+++ b/services/secure-api/src/api/admin/users.ts
@@ -1,0 +1,304 @@
+import { PrismaClient, type Prisma } from "@prisma/client";
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { recordAdminAction } from "../../utils/adminAudit";
+import { isBootstrapSuperuser } from "../../const/admin";
+import type { AdminEnv } from "./env";
+
+const prisma = new PrismaClient();
+
+const listQuery = z.object({
+  q: z.string().trim().max(100).optional(),
+  role: z.enum(["USER", "ADMIN", "SUPERUSER"]).optional(),
+  banned: z.enum(["true", "false"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(25),
+});
+
+const publicFields = {
+  id: true,
+  userId: true,
+  name: true,
+  nameEn: true,
+  email: true,
+  inschool: true,
+  role: true,
+  banned: true,
+  bannedReason: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.UserSelect;
+
+const app = new Hono<AdminEnv>()
+  // Directory search. The query matches a student ID, a name in either
+  // language, or an email, because staff arrive with whichever one the report
+  // they are acting on happened to mention.
+  .get("/", zValidator("query", listQuery), async (c) => {
+    const { q, role, banned, page, pageSize } = c.req.valid("query");
+
+    const where: Prisma.UserWhereInput = {
+      ...(role ? { role } : {}),
+      ...(banned ? { banned: banned === "true" } : {}),
+      ...(q
+        ? {
+            OR: [
+              { userId: { contains: q, mode: "insensitive" } },
+              { name: { contains: q, mode: "insensitive" } },
+              { nameEn: { contains: q, mode: "insensitive" } },
+              { email: { contains: q, mode: "insensitive" } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, users] = await Promise.all([
+      prisma.user.count({ where }),
+      prisma.user.findMany({
+        where,
+        select: publicFields,
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+    ]);
+
+    return c.json({ total, page, pageSize, users });
+  })
+
+  // Everything attached to one account, for answering "why can this person
+  // still see X" without opening a database console.
+  .get("/:userId", async (c) => {
+    const userId = c.req.param("userId");
+    const now = new Date();
+
+    const user = await prisma.user.findUnique({
+      where: { userId },
+      select: publicFields,
+    });
+
+    if (!user) return c.json({ error: "not_found" }, 404);
+
+    const [sessions, tokens, apiKeys, shareTokens, consents] =
+      await Promise.all([
+        prisma.authSessions.findMany({
+          where: { userId },
+          select: {
+            id: true,
+            state: true,
+            createdAt: true,
+            authenticatedAt: true,
+            expiresAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+          take: 20,
+        }),
+        prisma.token.findMany({
+          where: { userId, expiresAt: { gt: now } },
+          select: {
+            id: true,
+            type: true,
+            clientId: true,
+            scopes: true,
+            createdAt: true,
+            expiresAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+          take: 50,
+        }),
+        prisma.apiKey.findMany({
+          where: { userId },
+          select: {
+            id: true,
+            name: true,
+            scopes: true,
+            createdAt: true,
+            lastUsedAt: true,
+            expiresAt: true,
+            isRevoked: true,
+          },
+          orderBy: { createdAt: "desc" },
+        }),
+        prisma.calendarShareToken.findMany({
+          where: { userId },
+          select: {
+            id: true,
+            name: true,
+            createdAt: true,
+            lastUsedAt: true,
+            expiresAt: true,
+            revokedAt: true,
+            includeFullDetails: true,
+          },
+          orderBy: { createdAt: "desc" },
+        }),
+        prisma.clientConsent.findMany({
+          where: { userId },
+          select: {
+            id: true,
+            clientId: true,
+            scopes: true,
+            grantedAt: true,
+            updatedAt: true,
+          },
+        }),
+      ]);
+
+    return c.json({
+      user,
+      sessions,
+      tokens,
+      apiKeys,
+      shareTokens,
+      consents,
+      bootstrapSuperuser: isBootstrapSuperuser(userId),
+    });
+  })
+
+  // Granting staff access is the one action that can grant the power to grant
+  // staff access, so it is held to SUPERUSER rather than ADMIN.
+  .patch(
+    "/:userId/role",
+    requireAdmin("SUPERUSER"),
+    zValidator(
+      "json",
+      z.object({ role: z.enum(["USER", "ADMIN", "SUPERUSER"]) }),
+    ),
+    async (c) => {
+      const actor = c.get("user");
+      const userId = c.req.param("userId");
+      const { role } = c.req.valid("json");
+
+      if (userId === actor.userId) {
+        return c.json(
+          {
+            error: "invalid_request",
+            error_description: "You cannot change your own role",
+          },
+          400,
+        );
+      }
+
+      // The bootstrap account is re-promoted on its next sign-in anyway;
+      // refusing here avoids recording a change that silently reverts.
+      if (isBootstrapSuperuser(userId) && role !== "SUPERUSER") {
+        return c.json(
+          {
+            error: "invalid_request",
+            error_description:
+              "This account is a bootstrap superuser and cannot be demoted",
+          },
+          400,
+        );
+      }
+
+      const existing = await prisma.user.findUnique({ where: { userId } });
+      if (!existing) return c.json({ error: "not_found" }, 404);
+
+      const user = await prisma.user.update({
+        where: { userId },
+        data: { role },
+        select: publicFields,
+      });
+
+      await recordAdminAction({
+        actorId: actor.userId,
+        action: "user.role.update",
+        targetType: "user",
+        targetId: userId,
+        metadata: { from: existing.role, to: role },
+      });
+
+      return c.json(user);
+    },
+  )
+
+  // Suspend or restore an account.
+  .patch(
+    "/:userId/ban",
+    zValidator(
+      "json",
+      z.object({
+        banned: z.boolean(),
+        reason: z.string().trim().max(500).optional(),
+      }),
+    ),
+    async (c) => {
+      const actor = c.get("user");
+      const userId = c.req.param("userId");
+      const { banned, reason } = c.req.valid("json");
+
+      if (userId === actor.userId) {
+        return c.json(
+          {
+            error: "invalid_request",
+            error_description: "You cannot ban yourself",
+          },
+          400,
+        );
+      }
+
+      const existing = await prisma.user.findUnique({ where: { userId } });
+      if (!existing) return c.json({ error: "not_found" }, 404);
+
+      // An admin banning another admin is an escalation dressed as moderation.
+      if (banned && existing.role !== "USER" && actor.role !== "SUPERUSER") {
+        return c.json(
+          {
+            error: "forbidden",
+            error_description: "Only a superuser can suspend an administrator",
+          },
+          403,
+        );
+      }
+
+      const user = await prisma.user.update({
+        where: { userId },
+        data: { banned, bannedReason: banned ? (reason ?? null) : null },
+        select: publicFields,
+      });
+
+      // A ban that leaves live tokens behind is not a ban for another 30 days.
+      if (banned) {
+        await prisma.token.deleteMany({ where: { userId } });
+        await prisma.authSessions.deleteMany({ where: { userId } });
+      }
+
+      await recordAdminAction({
+        actorId: actor.userId,
+        action: banned ? "user.ban" : "user.unban",
+        targetType: "user",
+        targetId: userId,
+        metadata: reason ? { reason } : {},
+      });
+
+      return c.json(user);
+    },
+  )
+
+  // Sign an account out everywhere, without suspending it.
+  .delete("/:userId/sessions", async (c) => {
+    const actor = c.get("user");
+    const userId = c.req.param("userId");
+
+    const existing = await prisma.user.findUnique({ where: { userId } });
+    if (!existing) return c.json({ error: "not_found" }, 404);
+
+    const [tokens, sessions] = await Promise.all([
+      prisma.token.deleteMany({ where: { userId } }),
+      prisma.authSessions.deleteMany({ where: { userId } }),
+    ]);
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "user.sessions.revoke",
+      targetType: "user",
+      targetId: userId,
+      metadata: { tokens: tokens.count, sessions: sessions.count },
+    });
+
+    return c.json({ tokens: tokens.count, sessions: sessions.count });
+  });
+
+export default app;

--- a/services/secure-api/src/api/index.ts
+++ b/services/secure-api/src/api/index.ts
@@ -11,11 +11,11 @@ import adminHandler from "./admin";
 /**
  * Origins allowed to call the authenticated API with credentials.
  */
-const ALLOWED_ORIGINS = [
+const ALLOWED_ORIGINS = new Set([
   "https://nthumods.com",
   "http://localhost:3000",
   "http://localhost:5173",
-];
+]);
 
 const app = new Hono()
   .use(
@@ -24,7 +24,7 @@ const app = new Hono()
       // makes a reflected origin a real cross-site risk. The localhost entries
       // are what let the admin center be developed against a live auth server.
       origin: (origin) =>
-        ALLOWED_ORIGINS.includes(origin) ? origin : "https://nthumods.com",
+        ALLOWED_ORIGINS.has(origin) ? origin : "https://nthumods.com",
       allowHeaders: ["Authorization", "Content-Type"],
       allowMethods: ["GET", "POST", "OPTIONS", "DELETE", "PUT", "PATCH"],
       credentials: true,

--- a/services/secure-api/src/api/index.ts
+++ b/services/secure-api/src/api/index.ts
@@ -6,13 +6,27 @@ import replicationHandler from "./replication";
 import apiKeysHandler from "./apikeys";
 import calendarHandler from "./calendar";
 import courseDatesHandler from "./course-dates";
+import adminHandler from "./admin";
+
+/**
+ * Origins allowed to call the authenticated API with credentials.
+ */
+const ALLOWED_ORIGINS = [
+  "https://nthumods.com",
+  "http://localhost:3000",
+  "http://localhost:5173",
+];
 
 const app = new Hono()
   .use(
     cors({
-      origin: "https://nthumods.com",
-      allowHeaders: ["Authorization"],
-      allowMethods: ["GET", "POST", "OPTIONS", "DELETE", "PUT"],
+      // An explicit list rather than a wildcard, because `credentials: true`
+      // makes a reflected origin a real cross-site risk. The localhost entries
+      // are what let the admin center be developed against a live auth server.
+      origin: (origin) =>
+        ALLOWED_ORIGINS.includes(origin) ? origin : "https://nthumods.com",
+      allowHeaders: ["Authorization", "Content-Type"],
+      allowMethods: ["GET", "POST", "OPTIONS", "DELETE", "PUT", "PATCH"],
       credentials: true,
     }),
   )
@@ -20,6 +34,7 @@ const app = new Hono()
   .route("/replication", replicationHandler)
   .route("/apikeys", apiKeysHandler)
   .route("/calendar", calendarHandler)
-  .route("/course-dates", courseDatesHandler);
+  .route("/course-dates", courseDatesHandler)
+  .route("/admin", adminHandler);
 
 export default app;

--- a/services/secure-api/src/const/admin.ts
+++ b/services/secure-api/src/const/admin.ts
@@ -1,0 +1,13 @@
+/**
+ * Accounts that are superusers regardless of what the database says.
+ *
+ * The admin center gates itself on User.role, which is only reachable through
+ * the admin API, which itself requires a superuser. That is a closed loop on a
+ * fresh database, so the loop is opened here: these student IDs are promoted on
+ * every sign-in, which also means an accidental demotion cannot lock the team
+ * out of their own tools.
+ */
+export const BOOTSTRAP_SUPERUSERS: readonly string[] = ["111060062"];
+
+export const isBootstrapSuperuser = (userId: string) =>
+  BOOTSTRAP_SUPERUSERS.includes(userId);

--- a/services/secure-api/src/const/scopes.ts
+++ b/services/secure-api/src/const/scopes.ts
@@ -1,0 +1,18 @@
+/**
+ * Every scope the authorization server will issue.
+ *
+ * Shared between the authorize endpoint, which rejects anything outside this
+ * list, and the admin center's client registration form, so a client can never
+ * be registered asking for a scope that would then be refused at sign-in.
+ */
+export const VALID_SCOPES = [
+  "openid", // sub
+  "profile", // name, name_en, inschool
+  "email", // email
+  "offline_access",
+  "kv",
+  "calendar",
+  "planner",
+] as const;
+
+export type Scope = (typeof VALID_SCOPES)[number];

--- a/services/secure-api/src/middleware/requireAdmin.test.ts
+++ b/services/secure-api/src/middleware/requireAdmin.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AdminRole, User } from "@prisma/client";
+
+const userFindUnique = mock();
+
+mock.module("@prisma/client", () => ({
+  PrismaClient: class {
+    user = {
+      findUnique: userFindUnique,
+    };
+  },
+}));
+
+const { hasAtLeastRole, requireAdmin } = await import("./requireAdmin");
+
+type AdminEnv = {
+  Variables: {
+    user: User;
+  };
+};
+
+const makeUser = (role: AdminRole, banned = false) =>
+  ({
+    userId: "user-id",
+    role,
+    banned,
+  }) as User;
+
+const appFor = (user: User | undefined, minimum: AdminRole = "ADMIN") => {
+  const app = new Hono<AdminEnv>();
+
+  if (user) {
+    app.use("*", async (c, next) => {
+      c.set("user", user);
+      await next();
+    });
+  }
+
+  app.get("/private", requireAdmin(minimum), (c) => c.json({ ok: true }));
+  return app;
+};
+
+describe("hasAtLeastRole", () => {
+  test("ranks user below admin and superuser", () => {
+    expect(hasAtLeastRole("USER", "USER")).toBe(true);
+    expect(hasAtLeastRole("USER", "ADMIN")).toBe(false);
+    expect(hasAtLeastRole("ADMIN", "ADMIN")).toBe(true);
+    expect(hasAtLeastRole("ADMIN", "SUPERUSER")).toBe(false);
+    expect(hasAtLeastRole("SUPERUSER", "ADMIN")).toBe(true);
+    expect(hasAtLeastRole("SUPERUSER", "SUPERUSER")).toBe(true);
+  });
+});
+
+describe("requireAdmin", () => {
+  beforeEach(() => {
+    userFindUnique.mockReset();
+  });
+
+  test("returns 401 when there is no authenticated user", async () => {
+    const response = await appFor(undefined).request("/private");
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: "unauthorized",
+      error_description: "Access token required",
+    });
+  });
+
+  test("returns 403 for a regular user", async () => {
+    const response = await appFor(makeUser("USER")).request("/private");
+
+    expect(response.status).toBe(403);
+  });
+
+  test("returns 403 for a banned superuser", async () => {
+    const response = await appFor(makeUser("SUPERUSER", true)).request(
+      "/private",
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  test("allows an admin at the default minimum", async () => {
+    const response = await appFor(makeUser("ADMIN")).request("/private");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  test("allows a superuser at the default minimum", async () => {
+    const response = await appFor(makeUser("SUPERUSER")).request("/private");
+
+    expect(response.status).toBe(200);
+  });
+
+  test("refuses an admin when superuser access is required", async () => {
+    const response = await appFor(makeUser("ADMIN"), "SUPERUSER").request(
+      "/private",
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/services/secure-api/src/middleware/requireAdmin.ts
+++ b/services/secure-api/src/middleware/requireAdmin.ts
@@ -1,0 +1,49 @@
+import type { AdminRole, User } from "@prisma/client";
+import { createMiddleware } from "hono/factory";
+
+/**
+ * Gate a route on NTHUMods staff access.
+ *
+ * Runs after `requireAuth`, which has already put the account on the context.
+ * This is a check on the person, not on the token's OAuth scopes: an access
+ * token minted for any client belonging to an admin gets in, and a token
+ * carrying every scope in the system does not if the account is not staff.
+ */
+const RANK: Record<AdminRole, number> = {
+  USER: 0,
+  ADMIN: 1,
+  SUPERUSER: 2,
+};
+
+export const hasAtLeastRole = (role: AdminRole, minimum: AdminRole) =>
+  RANK[role] >= RANK[minimum];
+
+export const requireAdmin = (minimum: AdminRole = "ADMIN") =>
+  createMiddleware<{
+    Variables: {
+      user: User;
+    };
+  }>(async (c, next) => {
+    const user = c.get("user");
+
+    // Without an authenticated user there is nothing to authorise. Saying
+    // "forbidden" here would leak that the route exists to anyone unauthenticated.
+    if (!user) {
+      return c.json(
+        { error: "unauthorized", error_description: "Access token required" },
+        401,
+      );
+    }
+
+    if (user.banned || !hasAtLeastRole(user.role, minimum)) {
+      return c.json(
+        {
+          error: "forbidden",
+          error_description: "Administrator access required",
+        },
+        403,
+      );
+    }
+
+    await next();
+  });

--- a/services/secure-api/src/middleware/requireAuth.test.ts
+++ b/services/secure-api/src/middleware/requireAuth.test.ts
@@ -69,4 +69,35 @@ describe("requireAuth", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ userId: "user-id" });
   });
+
+  test("returns 403 when a valid access token belongs to a banned user", async () => {
+    tokenFindFirst.mockResolvedValueOnce({
+      token: "access-token",
+      type: "ACCESS",
+      userId: "user-id",
+      scopes: [],
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    userFindUnique.mockResolvedValueOnce({
+      userId: "user-id",
+      name: "Test User",
+      banned: true,
+    });
+
+    const app = new Hono().get("/private", requireAuth(), (c) =>
+      c.json({ ok: true }),
+    );
+
+    const response = await app.request("/private", {
+      headers: {
+        Authorization: "Bearer access-token",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "account_suspended",
+      error_description: "This account has been suspended",
+    });
+  });
 });

--- a/services/secure-api/src/middleware/requireAuth.ts
+++ b/services/secure-api/src/middleware/requireAuth.ts
@@ -37,6 +37,19 @@ export const requireAuth = (requiredScopes: string[] = []) =>
 
       if (!user) throw new Error("User not found");
 
+      // A ban has to bite immediately. Access tokens live 30 minutes and
+      // refresh tokens 30 days, so waiting for expiry would leave a suspended
+      // account with a working session for the rest of the month.
+      if (user.banned) {
+        return c.json(
+          {
+            error: "account_suspended",
+            error_description: "This account has been suspended",
+          },
+          403,
+        );
+      }
+
       c.set("user", user);
 
       if (requiredScopes.length > 0) {

--- a/services/secure-api/src/oidc.tsx
+++ b/services/secure-api/src/oidc.tsx
@@ -18,6 +18,8 @@ import {
   isConsentRequired,
   isPendingConsentValid,
 } from "./utils/consent";
+import { isBootstrapSuperuser } from "./const/admin";
+import { VALID_SCOPES } from "./const/scopes";
 
 const prisma = new PrismaClient();
 const ISSUER = "https://auth.nthumods.com";
@@ -25,16 +27,6 @@ const accessTokenExpiry: number = 30 * 60; // 30 minutes
 const refreshTokenExpiry: number = 30 * 24 * 60 * 60; // 30 days
 const sessionExpiry: number = 180 * 24 * 60 * 60; // 180 days
 const ID_TOKEN_EXPIRY = "1h";
-
-const VALID_SCOPES = [
-  "openid", // sub
-  "profile", // name, name_en, inschool
-  "email", // email
-  "offline_access",
-  "kv",
-  "calendar",
-  "planner",
-];
 
 async function verifyPKCE(
   codeVerifier: string,
@@ -301,7 +293,8 @@ const app = new Hono()
             // Deduplicated, so a repeated scope cannot make two different
             // requests compare equal downstream.
             const scopes = [...new Set(scope.split(" ").filter(Boolean))];
-            if (!scopes.every((scope) => VALID_SCOPES.includes(scope))) {
+            const allowed: readonly string[] = VALID_SCOPES;
+            if (!scopes.every((scope) => allowed.includes(scope))) {
               throw new Error("Invalid scopes");
             }
             return scopes;
@@ -714,6 +707,13 @@ const app = new Hono()
       // Authentication Approved
 
       // Store or update user in Prisma
+      // A bootstrap superuser is re-asserted on every sign-in so the admin
+      // center always has someone who can grant access, even on a database
+      // that has never had an admin.
+      const bootstrapRole = isBootstrapSuperuser(user.userid)
+        ? ({ role: "SUPERUSER" } as const)
+        : {};
+
       const upsertedUser = await prisma.user.upsert({
         where: { userId: user.userid },
         update: {
@@ -723,6 +723,7 @@ const app = new Hono()
           inschool: user.inschool || false,
           cid: user.cid,
           lmsid: user.lmsid,
+          ...bootstrapRole,
         },
         create: {
           userId: user.userid,
@@ -732,8 +733,22 @@ const app = new Hono()
           inschool: user.inschool || false,
           cid: user.cid,
           lmsid: user.lmsid,
+          ...bootstrapRole,
         },
       });
+
+      // A banned account is refused here rather than after tokens exist, so a
+      // ban takes effect on the next sign-in without waiting for anything to
+      // expire. requireAuth turns away tokens that were already issued.
+      if (upsertedUser.banned) {
+        return c.redirect(
+          buildClientRedirect(redirectTarget, {
+            error: "access_denied",
+            error_description: "This account has been suspended.",
+            state: clientState ?? undefined,
+          }),
+        );
+      }
 
       // The user passed the consent screen before this round trip started, so
       // their identity can now be attached to that approval.

--- a/services/secure-api/src/utils/adminAudit.ts
+++ b/services/secure-api/src/utils/adminAudit.ts
@@ -1,0 +1,32 @@
+import { PrismaClient, type Prisma } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+/**
+ * Record an administrative write.
+ *
+ * Failures are swallowed on purpose: an audit row that cannot be written is
+ * worth a log line, but it is not worth failing a ban that has already been
+ * applied, which would leave the caller unsure whether the action took effect.
+ */
+export async function recordAdminAction(entry: {
+  actorId: string;
+  action: string;
+  targetType?: string;
+  targetId?: string;
+  metadata?: Prisma.InputJsonValue;
+}) {
+  try {
+    await prisma.adminAuditLog.create({
+      data: {
+        actorId: entry.actorId,
+        action: entry.action,
+        targetType: entry.targetType,
+        targetId: entry.targetId,
+        metadata: entry.metadata,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to write admin audit log", entry.action, error);
+  }
+}


### PR DESCRIPTION
Adds a staff-only admin center at `/:lang/admin`, gated by our own OIDC identity rather than a shared password or a separate tool.

## Access model

Staff access is a new `AdminRole` on `User` (`USER` / `ADMIN` / `SUPERUSER`), deliberately separate from OAuth scopes: scopes say what a *client application* may ask for on a user's behalf, the role says what the *person* may do inside NTHUMods. `requireAdmin` runs after `requireAuth` and checks the account, so an access token minted for any client belonging to an admin gets in, and a token carrying every scope does not if the account is not staff.

`111060062` is seeded as the first superuser by the migration **and** re-asserted on every sign-in. The console gates on `User.role`, which is only reachable through an API that itself requires a superuser — a closed loop on a fresh database, and one an accidental demotion would lock the team out of.

Granting staff access is the one action that can grant the power to grant staff access, so role changes are `SUPERUSER`-only. An admin cannot suspend another admin; nobody can change their own role, suspend themselves, or revoke their own sessions.

## Bans take effect immediately

`banned` is enforced in three places, because an access token lives 30 minutes and a refresh token 30 days — waiting for expiry would leave a suspended account working for the rest of the month. `requireAuth` turns away existing tokens, `/authorize` refuses a new sign-in, and the ban itself deletes every token and session.

## API

`/api/admin` on secure-api: `/me`, `/stats`, `/users`, `/announcements`, `/clients` (superuser only), `/audit`.

`/me` sits deliberately *outside* the staff gate so the web app can ask "am I staff?" and get an ordinary 200 answer instead of interpreting a 403 from a route it was never meant to call. Everything else is a separate router mounted behind `requireAdmin`, rather than a `use()` placed after `/me` — so the gate does not depend on the reader knowing that Hono runs middleware in registration order.

Every administrative write lands in `AdminAuditLog`, attributed to the acting person. There is no delete or edit route for it and there is not meant to be one.

## Console

Overview (accounts, sessions, credentials, content, signup trend, tokens by client), Users (search by student ID / name in either language / email, filters in the URL, full detail with sessions, tokens, API keys, calendar links and consents), Announcements (CRUD with a live banner preview and Taipei-correct dates), OAuth Clients (registration, one-time secret display, rotation), Audit Log. English-only by design — it is an internal staff tool, so it adds no dictionary keys. Staff reach it from a sidebar entry that nobody else sees.

## Verification

Run against the live auth and content databases, not just read:

- Full announcement round-trip — create, patch, delete — each one audited and attributed. Test row removed afterwards.
- `javascript:` links, inverted date windows, invalid scopes and first-party client deletion all refused with the right status.
- 95 secure-api tests, 103 web tests, 0 new typecheck errors (the repo has 8 pre-existing ones elsewhere).

Five defects were found this way rather than by reading the diff, and are fixed in `89c5f84c`. The one worth calling out: client registration validated scopes against the consent enum only, so editing `nthumods-api` would have silently dropped `introspect:nthumods`, the only scope it has.

One performance bug was mine: `DATABASE_URL` goes through pgbouncer, which pins Prisma to a single connection, so the overview's `Promise.all` of thirteen counts queued rather than running in parallel — twelve seconds, past Bun's 10s idle timeout. It is one statement now.

## Deploying

The migration is additive (new enum, three defaulted columns, one new table) and **has already been applied** to the auth database, so the currently deployed secure-api is unaffected and keeps running. Merging builds the image; secure-api still needs its own Coolify deploy before `/api/admin` exists in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wapcwZKVzLpmhGkVxjwKU
