### PR TITLE
ci: deploy the Coolify app that actually serves auth.nthumods.com

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -296,8 +296,13 @@ jobs:
           docker push ${{ env.IMAGE_NAME }}-secure-api:${{ github.sha }}
           docker push ${{ env.IMAGE_NAME }}-secure-api:latest
 
+      # This uuid is the Coolify app that actually serves auth.nthumods.com.
+      # It used to point at a second app registered against the same image but
+      # with no domain attached, so deploys succeeded against nothing and the
+      # live server only moved when someone redeployed it by hand. Check the
+      # target's fqdn before repointing this.
       - name: Trigger Coolify deployment
         if: success()
         run: |
-          curl --request GET "https://delta.nthumods.com/api/v1/deploy?uuid=ag4g0sg8cosoo0cgcccwg4w8&force=false" \
+          curl --fail --request GET "https://delta.nthumods.com/api/v1/deploy?uuid=nwwc8owkwo04c0owgc4kgkc8&force=false" \
             --header "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}"


### PR DESCRIPTION
Two Coolify apps were registered against the same `ghcr.io/nthumodifications/courseweb-secure-api` image:

| uuid | fqdn | build pack | deployed by |
|---|---|---|---|
| `ag4g0sg8cosoo0cgcccwg4w8` | **none** | dockercompose | this workflow |
| `nwwc8owkwo04c0owgc4kgkc8` | **https://auth.nthumods.com** | dockerimage `:latest` | nobody |

The trigger added in #820 pointed at the first one. It has no domain attached, so every secure-api deploy since June succeeded against an app serving no traffic, while `auth.nthumods.com` only moved when someone redeployed it by hand from the Coolify UI.

Because both apps pull the same image and the API returns 200 either way, CI stayed green throughout. It surfaced this week: the admin center merged, the pipeline went green, and `/api/admin/me` still returned `404 Not Found` in production. It is also, in hindsight, why the JWKS outage needed a manual redeploy — that was the workaround, not the fix.

This repoints the step at the app that owns the domain, and adds `--fail` so a rejected call (an expired `COOLIFY_TOKEN`, say) turns the step red instead of passing on a 401 response body.

The other app is being deleted separately. Every environment variable the service actually reads — `DATABASE_URL`, `DIRECT_URL`, `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY`, the four `NTHU_OAUTH_*`, `FIREBASE_SERVICE_ACCOUNT`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` — is already set on the surviving app. The extras the dead one carried (`OAUTH_*`, the split `FIREBASE_PROJECT_ID`/`CLIENT_EMAIL`/`PRIVATE_KEY` trio, `NODE_ENV`, `PORT`) are docker-compose scaffolding no code path reads: `NODE_ENV=production` comes from the `start` script and the port from `EXPOSE 5002`.

Verified by deploying `nwwc8owkwo04c0owgc4kgkc8` by hand — all six `/api/admin/*` routes now answer `unauthorized` instead of `404`, and `/.well-known/jwks.json` still serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wapcwZKVzLpmhGkVxjwKU
