### PR TITLE
feat(admin): recruitment review, inline role changes, and a gate fix

### DIFF
--- a/apps/web/src/app/[lang]/admin/api.ts
+++ b/apps/web/src/app/[lang]/admin/api.ts
@@ -129,6 +129,24 @@ export type AdminClient = {
   consents: number;
 };
 
+export type RecruitmentStatus =
+  | "submitted"
+  | "reviewing"
+  | "accepted"
+  | "rejected";
+
+export type RecruitmentApplication = {
+  id: string;
+  applicant_sub: string;
+  role: string;
+  statement: string;
+  contact_preference: string;
+  links: Record<string, string>;
+  status: RecruitmentStatus;
+  created_at: string;
+  updated_at: string;
+};
+
 export type AdminAuditEntry = {
   id: string;
   actorId: string;
@@ -187,6 +205,7 @@ export const adminKeys = {
   announcements: ["admin", "announcements"] as const,
   oauthClients: ["admin", "clients"] as const,
   audit: (params: unknown) => ["admin", "audit", params] as const,
+  recruitment: (params: unknown) => ["admin", "recruitment", params] as const,
 };
 
 /**
@@ -197,19 +216,22 @@ export const adminKeys = {
  */
 export const useAdminIdentity = () => {
   const token = useAdminToken();
-  const auth = useAuth();
 
   return useQuery<AdminIdentity | null>({
     queryKey: adminKeys.me,
     // The identity decides whether the rest of the console renders at all;
     // re-checking on focus means a revoked role takes effect on tab switch.
     staleTime: 60_000,
-    enabled: !auth.isLoading,
+    // Gated on the token existing, not merely on auth having finished loading.
+    // oidc-client-ts restores its session a tick after `isLoading` clears, so
+    // the looser condition let this run with no token, resolve `null`, and
+    // cache that for a minute — a staff member opening the console cold was
+    // told the page did not exist until the cache expired.
+    enabled: Boolean(token),
     queryFn: async () => {
-      if (!token) return null;
       const response = await authClient.api.admin.me.$get(
         {},
-        { headers: authHeaders(token) },
+        { headers: authHeaders(token!) },
       );
       if (response.status === 401 || response.status === 403) return null;
       return unwrap<AdminIdentity>(response as unknown as Response);
@@ -653,6 +675,75 @@ export const useAdminAudit = (params: {
         { headers: authHeaders(requireToken(token)) },
       );
       return unwrap(response as unknown as Response);
+    },
+  });
+};
+
+export const useRecruitmentApplications = (params: {
+  status?: RecruitmentStatus;
+  role?: string;
+}) => {
+  const token = useAdminToken();
+  return useQuery<RecruitmentApplication[]>({
+    queryKey: adminKeys.recruitment(params),
+    enabled: Boolean(token),
+    queryFn: async () => {
+      const response = await authClient.api.admin.recruitment.$get(
+        {
+          query: {
+            ...(params.status ? { status: params.status } : {}),
+            ...(params.role ? { role: params.role } : {}),
+          },
+        },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<RecruitmentApplication[]>(response as unknown as Response);
+    },
+  });
+};
+
+export const useSetRecruitmentStatus = () => {
+  const token = useAdminToken();
+  const invalidate = useInvalidateAdmin();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      status,
+    }: {
+      id: string;
+      status: RecruitmentStatus;
+    }) => {
+      const response = await authClient.api.admin.recruitment[":id"].$patch(
+        { param: { id }, json: { status } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<RecruitmentApplication>(response as unknown as Response);
+    },
+    onSuccess: invalidate,
+  });
+};
+
+/**
+ * Mint a short-lived link to an applicant's CV.
+ *
+ * Not a query: fetching it is an audited act, so it happens when a reviewer
+ * asks for it rather than whenever a list happens to render.
+ */
+export const useRecruitmentResumeUrl = () => {
+  const token = useAdminToken();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const response = await authClient.api.admin.recruitment[":id"][
+        "resume"
+      ].$post(
+        { param: { id } },
+        { headers: authHeaders(requireToken(token)) },
+      );
+      return unwrap<{ url: string; expiresInSeconds: number }>(
+        response as unknown as Response,
+      );
     },
   });
 };

--- a/apps/web/src/app/[lang]/admin/api.ts
+++ b/apps/web/src/app/[lang]/admin/api.ts
@@ -737,10 +737,7 @@ export const useRecruitmentResumeUrl = () => {
     mutationFn: async (id: string) => {
       const response = await authClient.api.admin.recruitment[":id"][
         "resume"
-      ].$post(
-        { param: { id } },
-        { headers: authHeaders(requireToken(token)) },
-      );
+      ].$post({ param: { id } }, { headers: authHeaders(requireToken(token)) });
       return unwrap<{ url: string; expiresInSeconds: number }>(
         response as unknown as Response,
       );

--- a/apps/web/src/app/[lang]/admin/audit/page.tsx
+++ b/apps/web/src/app/[lang]/admin/audit/page.tsx
@@ -30,7 +30,12 @@ import {
 import { useAdminAudit } from "../api";
 
 const PAGE_SIZE = 25;
-const ACTION_PREFIXES = ["user.", "announcement.", "client."] as const;
+const ACTION_PREFIXES = [
+  "user.",
+  "announcement.",
+  "client.",
+  "recruitment.",
+] as const;
 
 type JsonObject = Record<string, unknown>;
 

--- a/apps/web/src/app/[lang]/admin/layout.tsx
+++ b/apps/web/src/app/[lang]/admin/layout.tsx
@@ -9,6 +9,7 @@ import {
   Megaphone,
   ScrollText,
   ShieldAlert,
+  UserPlus,
   Users,
 } from "lucide-react";
 import { useAdminIdentity } from "./api";
@@ -25,6 +26,7 @@ const NAV = [
   { to: "", label: "Overview", icon: Activity, end: true },
   { to: "users", label: "Users", icon: Users, end: false },
   { to: "announcements", label: "Announcements", icon: Megaphone, end: false },
+  { to: "recruitment", label: "Recruitment", icon: UserPlus, end: false },
   { to: "clients", label: "OAuth Clients", icon: KeyRound, superuser: true },
   { to: "audit", label: "Audit Log", icon: ScrollText, end: false },
 ] as const;
@@ -51,11 +53,16 @@ const CenteredNotice = ({
 const AdminLayout = () => {
   const { lang } = useParams<{ lang: string }>();
   const auth = useAuth();
-  const { data: identity, isLoading, isError } = useAdminIdentity();
+  const { data: identity, isError, status } = useAdminIdentity();
+
+  // While signed in, "no answer yet" is not "not staff". The identity query is
+  // disabled until a token exists, so a disabled-but-unanswered query has to
+  // read as still checking rather than falling through to the 404 below.
+  const identityPending = auth.isAuthenticated && status === "pending";
 
   const base = `/${lang === "en" ? "en" : "zh"}/admin`;
 
-  if (auth.isLoading || isLoading) {
+  if (auth.isLoading || identityPending) {
     return (
       <CenteredNotice
         title="Checking access"

--- a/apps/web/src/app/[lang]/admin/recruitment/page.tsx
+++ b/apps/web/src/app/[lang]/admin/recruitment/page.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  useToast,
+} from "@courseweb/ui";
+import { ExternalLink, FileText } from "lucide-react";
+import {
+  EmptyState,
+  ErrorState,
+  InlineSpinner,
+  Mono,
+  PageHeader,
+  formatDateTime,
+  relativeTime,
+} from "../components";
+import {
+  useRecruitmentApplications,
+  useRecruitmentResumeUrl,
+  useSetRecruitmentStatus,
+  type RecruitmentApplication,
+  type RecruitmentStatus,
+} from "../api";
+
+/**
+ * Recruitment review.
+ *
+ * Applications are personal data — a statement someone wrote about themselves,
+ * their links, their CV — so this page shows one applicant at a time rather
+ * than laying every statement out in a grid to be skimmed.
+ */
+
+const STATUSES: RecruitmentStatus[] = [
+  "submitted",
+  "reviewing",
+  "accepted",
+  "rejected",
+];
+
+const STATUS_STYLES: Record<RecruitmentStatus, string> = {
+  submitted: "border-transparent bg-primary text-primary-foreground",
+  reviewing: "border-transparent bg-secondary text-secondary-foreground",
+  accepted: "border-transparent bg-emerald-600 text-white",
+  rejected: "border-border text-muted-foreground",
+};
+
+const ROLES = [
+  "maintainer",
+  "administrator",
+  "frontend",
+  "backend",
+  "community",
+];
+
+const ResumeButton = ({ id }: { id: string }) => {
+  const { toast } = useToast();
+  const resume = useRecruitmentResumeUrl();
+
+  const open = async () => {
+    try {
+      const { url } = await resume.mutateAsync(id);
+      // Opened rather than downloaded: the link expires in five minutes, and a
+      // file left in Downloads outlives the reason it was fetched.
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      toast({
+        title: "Could not open the CV",
+        description: error instanceof Error ? error.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={open}
+      disabled={resume.isPending}
+    >
+      {resume.isPending ? <InlineSpinner /> : <FileText className="h-4 w-4" />}
+      View CV
+    </Button>
+  );
+};
+
+const ApplicationCard = ({
+  application,
+}: {
+  application: RecruitmentApplication;
+}) => {
+  const { toast } = useToast();
+  const setStatus = useSetRecruitmentStatus();
+
+  const changeStatus = async (status: RecruitmentStatus) => {
+    try {
+      await setStatus.mutateAsync({ id: application.id, status });
+      toast({ title: `Marked ${status}` });
+    } catch (error) {
+      toast({
+        title: "Could not update the application",
+        description: error instanceof Error ? error.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  const links = Object.entries(application.links ?? {}).filter(
+    ([, value]) => typeof value === "string" && value,
+  );
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium capitalize">{application.role}</span>
+              <Badge
+                variant="outline"
+                className={STATUS_STYLES[application.status]}
+              >
+                {application.status}
+              </Badge>
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              <Mono>{application.applicant_sub}</Mono> · applied{" "}
+              {formatDateTime(application.created_at)} (
+              {relativeTime(application.created_at)}) · prefers{" "}
+              {application.contact_preference}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <ResumeButton id={application.id} />
+            <Select
+              value={application.status}
+              onValueChange={(value) =>
+                changeStatus(value as RecruitmentStatus)
+              }
+              disabled={setStatus.isPending}
+            >
+              <SelectTrigger className="w-[140px]" aria-label="Set status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUSES.map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {status}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <p className="whitespace-pre-wrap text-sm text-foreground">
+          {application.statement}
+        </p>
+
+        {links.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {links.map(([label, url]) => (
+              <a
+                key={label}
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted"
+              >
+                {label}
+                <ExternalLink className="h-3 w-3" aria-hidden />
+              </a>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+const AdminRecruitmentPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const status = searchParams.get("status") ?? "all";
+  const role = searchParams.get("role") ?? "all";
+
+  const query = useRecruitmentApplications({
+    status: status === "all" ? undefined : (status as RecruitmentStatus),
+    role: role === "all" ? undefined : role,
+  });
+
+  const updateParam = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value === "all") next.delete(key);
+    else next.set(key, value);
+    setSearchParams(next, { replace: true });
+  };
+
+  const [expanded, setExpanded] = useState(false);
+  const applications = query.data ?? [];
+  const visible = expanded ? applications : applications.slice(0, 20);
+
+  return (
+    <>
+      <PageHeader
+        title="Recruitment"
+        description="Applications to join the NTHUMods team."
+      />
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Select value={status} onValueChange={(v) => updateParam("status", v)}>
+          <SelectTrigger className="w-[170px]" aria-label="Filter by status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            {STATUSES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {s}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={role} onValueChange={(v) => updateParam("role", v)}>
+          <SelectTrigger className="w-[170px]" aria-label="Filter by role">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All roles</SelectItem>
+            {ROLES.map((r) => (
+              <SelectItem key={r} value={r}>
+                {r}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {!query.isLoading && (
+          <span className="text-sm text-muted-foreground">
+            {applications.length} application
+            {applications.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+
+      {query.isError && <ErrorState error={query.error} />}
+
+      {query.isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-40 w-full" />
+          ))}
+        </div>
+      ) : applications.length === 0 ? (
+        <EmptyState>No applications match those filters.</EmptyState>
+      ) : (
+        <div className="space-y-3">
+          {visible.map((application) => (
+            <ApplicationCard key={application.id} application={application} />
+          ))}
+          {!expanded && applications.length > visible.length && (
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => setExpanded(true)}
+            >
+              Show {applications.length - visible.length} more
+            </Button>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default AdminRecruitmentPage;

--- a/apps/web/src/app/[lang]/admin/users/page.tsx
+++ b/apps/web/src/app/[lang]/admin/users/page.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import {
+  Link,
+  useOutletContext,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import { useDebounceValue } from "usehooks-ts";
 import {
   Badge,
   Button,
   Input,
+  useToast,
   Select,
   SelectContent,
   SelectItem,
@@ -27,9 +33,71 @@ import {
   RoleBadge,
   formatDateTime,
 } from "../components";
-import { useAdminUsers, type AdminRole } from "../api";
+import {
+  useAdminUsers,
+  useSetUserRole,
+  type AdminIdentity,
+  type AdminRole,
+  type AdminUser,
+} from "../api";
 
 const PAGE_SIZE = 25;
+
+/**
+ * Staff access, changed from the row rather than only from the detail page.
+ *
+ * Promoting somebody is the single most common reason to open this table, and
+ * making it a two-page trip was the main thing people could not find. Rendered
+ * only for a superuser, since that is who the server lets change a role at all.
+ */
+const RoleCell = ({
+  user,
+  identity,
+}: {
+  user: AdminUser;
+  identity: AdminIdentity;
+}) => {
+  const { toast } = useToast();
+  const setRole = useSetUserRole();
+
+  if (!identity.isSuperuser || user.userId === identity.userId) {
+    return <RoleBadge role={user.role} />;
+  }
+
+  const change = async (role: AdminRole) => {
+    if (role === user.role) return;
+    try {
+      await setRole.mutateAsync({ userId: user.userId, role });
+      toast({ title: `${user.userId} is now ${role.toLowerCase()}` });
+    } catch (error) {
+      toast({
+        title: "Could not change the role",
+        description: error instanceof Error ? error.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Select
+      value={user.role}
+      onValueChange={(value) => change(value as AdminRole)}
+      disabled={setRole.isPending}
+    >
+      <SelectTrigger
+        className="h-8 w-[124px]"
+        aria-label={`Role for ${user.userId}`}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="USER">User</SelectItem>
+        <SelectItem value="ADMIN">Admin</SelectItem>
+        <SelectItem value="SUPERUSER">Superuser</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+};
 
 /**
  * The user directory.
@@ -39,6 +107,7 @@ const PAGE_SIZE = 25;
  */
 const AdminUsersPage = () => {
   const { lang } = useParams<{ lang: string }>();
+  const identity = useOutletContext<AdminIdentity>();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
@@ -134,7 +203,7 @@ const AdminUsersPage = () => {
               <TableHead className="w-[120px]">Student ID</TableHead>
               <TableHead>Name</TableHead>
               <TableHead className="hidden md:table-cell">Email</TableHead>
-              <TableHead className="w-[110px]">Role</TableHead>
+              <TableHead className="w-[140px]">Role</TableHead>
               <TableHead className="w-[110px]">Status</TableHead>
               <TableHead className="hidden lg:table-cell w-[150px]">
                 Joined
@@ -171,7 +240,7 @@ const AdminUsersPage = () => {
                   <Mono>{user.email}</Mono>
                 </TableCell>
                 <TableCell>
-                  <RoleBadge role={user.role} />
+                  <RoleCell user={user} identity={identity} />
                 </TableCell>
                 <TableCell>
                   {user.banned ? (

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -112,6 +112,9 @@ const AdminAnnouncementsPage = lazy(
 );
 const AdminClientsPage = lazy(() => import("@/app/[lang]/admin/clients/page"));
 const AdminAuditPage = lazy(() => import("@/app/[lang]/admin/audit/page"));
+const AdminRecruitmentPage = lazy(
+  () => import("@/app/[lang]/admin/recruitment/page"),
+);
 
 // Separate layout page
 const WaitlistPage = lazy(() => import("@/app/[lang]/waitlist/page"));
@@ -519,6 +522,7 @@ export const router = createBrowserRouter([
               { path: "users", element: <AdminUsersPage /> },
               { path: "users/:userId", element: <AdminUserDetailPage /> },
               { path: "announcements", element: <AdminAnnouncementsPage /> },
+              { path: "recruitment", element: <AdminRecruitmentPage /> },
               { path: "clients", element: <AdminClientsPage /> },
               { path: "audit", element: <AdminAuditPage /> },
             ],

--- a/services/secure-api/src/api/admin/index.ts
+++ b/services/secure-api/src/api/admin/index.ts
@@ -7,6 +7,7 @@ import usersHandler from "./users";
 import announcementsHandler from "./announcements";
 import clientsHandler from "./clients";
 import auditHandler from "./audit";
+import recruitmentHandler from "./recruitment";
 
 /**
  * The NTHUMods admin center's API.
@@ -28,6 +29,7 @@ const gated = new Hono<AdminEnv>()
   .route("/stats", statsHandler)
   .route("/users", usersHandler)
   .route("/announcements", announcementsHandler)
+  .route("/recruitment", recruitmentHandler)
   .route("/clients", clientsHandler)
   .route("/audit", auditHandler);
 

--- a/services/secure-api/src/api/admin/recruitment.ts
+++ b/services/secure-api/src/api/admin/recruitment.ts
@@ -1,0 +1,154 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import supabase from "../../config/supabase";
+import { recordAdminAction } from "../../utils/adminAudit";
+import type { AdminEnv } from "./env";
+
+/**
+ * Recruitment applications.
+ *
+ * Applicants submit through the main API into `public.recruitment_applications`,
+ * a table with RLS that grants browser roles nothing at all — until now there
+ * was no way to read an application short of a database console, so every
+ * submission went into a drawer nobody could open.
+ *
+ * Everything here is personal data: a statement someone wrote about themselves,
+ * their contact preference, their links and their CV. It is read with the
+ * service role, behind the staff gate, and every read of a CV is audited.
+ */
+
+const RESUME_BUCKET = "resumes";
+
+/** Matches the statuses the table's CHECK constraint allows. */
+const STATUS = z.enum(["submitted", "reviewing", "accepted", "rejected"]);
+
+const app = new Hono<AdminEnv>()
+  .get(
+    "/",
+    zValidator(
+      "query",
+      z.object({
+        status: STATUS.optional(),
+        role: z.string().trim().max(50).optional(),
+      }),
+    ),
+    async (c) => {
+      const { status, role } = c.req.valid("query");
+
+      let query = supabase
+        .from("recruitment_applications")
+        .select("*")
+        .order("created_at", { ascending: false });
+
+      if (status) query = query.eq("status", status);
+      if (role) query = query.eq("role", role);
+
+      const { data, error } = await query;
+
+      if (error) {
+        console.error("admin recruitment: list failed", error.message);
+        return c.json({ error: "upstream_error" }, 502);
+      }
+
+      // The CV path is deliberately not returned. It is only useful through a
+      // signed URL, and handing every list response an object path invites
+      // someone to build a link to it.
+      const applications = (data ?? []).map(
+        ({ resume_object_path, ...application }) => application,
+      );
+
+      return c.json(applications);
+    },
+  )
+
+  .patch(
+    "/:id",
+    zValidator("json", z.object({ status: STATUS })),
+    async (c) => {
+      const actor = c.get("user");
+      const id = c.req.param("id");
+      const { status } = c.req.valid("json");
+
+      const { data: existing, error: readError } = await supabase
+        .from("recruitment_applications")
+        .select("id, status")
+        .eq("id", id)
+        .maybeSingle();
+
+      if (readError) {
+        console.error("admin recruitment: read failed", readError.message);
+        return c.json({ error: "upstream_error" }, 502);
+      }
+      if (!existing) return c.json({ error: "not_found" }, 404);
+
+      const { data, error } = await supabase
+        .from("recruitment_applications")
+        .update({ status, updated_at: new Date().toISOString() })
+        .eq("id", id)
+        .select()
+        .maybeSingle();
+
+      if (error) {
+        console.error("admin recruitment: update failed", error.message);
+        return c.json({ error: "upstream_error" }, 502);
+      }
+      if (!data) return c.json({ error: "not_found" }, 404);
+
+      await recordAdminAction({
+        actorId: actor.userId,
+        action: "recruitment.status",
+        targetType: "recruitment_application",
+        targetId: id,
+        metadata: { from: existing.status, to: status },
+      });
+
+      const { resume_object_path, ...application } = data;
+      return c.json(application);
+    },
+  )
+
+  // A short-lived link to one applicant's CV.
+  //
+  // Signed rather than proxied so the PDF never passes through this service,
+  // and audited because reading someone's CV is an act worth being able to
+  // attribute later. Five minutes is enough to open it once.
+  .post("/:id/resume", async (c) => {
+    const actor = c.get("user");
+    const id = c.req.param("id");
+
+    const { data: application, error: readError } = await supabase
+      .from("recruitment_applications")
+      .select("id, resume_object_path, applicant_sub")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (readError) {
+      console.error("admin recruitment: read failed", readError.message);
+      return c.json({ error: "upstream_error" }, 502);
+    }
+    if (!application) return c.json({ error: "not_found" }, 404);
+
+    const { data, error } = await supabase.storage
+      .from(RESUME_BUCKET)
+      .createSignedUrl(application.resume_object_path, 300);
+
+    if (error || !data) {
+      console.error(
+        "admin recruitment: signing failed",
+        error?.message ?? "no url returned",
+      );
+      return c.json({ error: "upstream_error" }, 502);
+    }
+
+    await recordAdminAction({
+      actorId: actor.userId,
+      action: "recruitment.resume.view",
+      targetType: "recruitment_application",
+      targetId: id,
+    });
+
+    return c.json({ url: data.signedUrl, expiresInSeconds: 300 });
+  });
+
+export default app;


### PR DESCRIPTION
Three things, all found by using the console rather than reading it.

## Recruitment review

Applications land in `public.recruitment_applications`, a table whose RLS grants browser roles nothing at all, and `services/api/src/recruit.ts` only ever exposed "submit" and "read your own". An application could not be read without a database console — every submission went into a drawer nobody could open.

Adds a review section: filter by status and role, read the statement and links, move an application through `submitted` / `reviewing` / `accepted` / `rejected`.

Applications are personal data, so the handling is deliberate:

- CVs are five-minute **signed URLs**, not proxied through the service.
- The storage object path is never returned in a list response — handing one out invites building a link to it.
- Both the status change and **every CV view** are audited. Reading somebody's CV is worth being able to attribute afterwards.
- One applicant per card rather than a grid, so statements are read rather than skimmed.

## Roles from the Users table

Promoting somebody is the main reason to open that table, and it previously meant a trip to the detail page — which is why the capability read as missing entirely. The row now carries a role Select, rendered only for a superuser and never on your own row (the server refuses that anyway).

## A real gate bug

`useAdminIdentity` was enabled as soon as `auth.isLoading` cleared, but oidc-client-ts restores its session a tick later. The query ran with no token, resolved `null`, and `staleTime: 60_000` kept it — so a staff member opening the console cold was shown **"Page not found"** until the cache expired. It is gated on the token now, and the layout treats an unanswered identity as "checking" rather than "not staff".

This would have hit production on any cold load that lost the race, so it is the most valuable thing in this PR.

## Verification

Run against the live databases with a superuser token, using disposable records that were deleted afterwards:

- Seeded an application and a dummy CV: list renders, links render, status moved `submitted → reviewing`, signed CV URL issued, `{"status":"hired"}` rejected by the enum. Row and storage object removed.
- Created a throwaway account and promoted it `USER → ADMIN → SUPERUSER`; changing your own role still refused with `You cannot change your own role`. Account deleted.
- Confirmed a list response carries no `resume_object_path`.
- 95 secure-api tests pass, 0 admin typecheck errors, prettier clean.

Audit action filter gains a `recruitment.` group so the new entries are findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wapcwZKVzLpmhGkVxjwKU
