### PR TITLE
fix(api): stop the OIDC CORS policy answering /api preflights

### DIFF
--- a/services/secure-api/src/__tests__/cors.test.ts
+++ b/services/secure-api/src/__tests__/cors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, mock, test } from "bun:test";
+
+/**
+ * The OIDC app is mounted at "/" ahead of the /api router, and Hono's cors()
+ * answers an OPTIONS preflight itself without calling next(). A "*" match here
+ * therefore decides CORS for the whole service, including /api/**, which has
+ * its own credentialed, origin-restricted policy with a wider method list.
+ *
+ * That is how `PATCH /api/admin/users/:id/role` came to be blocked in the
+ * browser while the route worked from curl: the preflight was answered by this
+ * app, advertising only GET and POST.
+ *
+ * Asserted against the OIDC app alone rather than the composed service. Pulling
+ * in the /api router would evaluate every admin handler under this file's
+ * Prisma stub, and bun's module mocks are process-wide — the handlers' own test
+ * files would then import an already-evaluated module and fail.
+ */
+
+mock.module("@prisma/client", () => ({
+  PrismaClient: class {},
+  TokenType: { ACCESS: "ACCESS", REFRESH: "REFRESH" },
+}));
+
+const { default: oidc } = await import("../oidc");
+
+const preflight = (path: string, method: string) =>
+  oidc.request(path, {
+    method: "OPTIONS",
+    headers: {
+      Origin: "https://nthumods.com",
+      "Access-Control-Request-Method": method,
+      "Access-Control-Request-Headers": "authorization,content-type",
+    },
+  });
+
+describe("OIDC CORS scope", () => {
+  test("does not answer preflights for /api, which owns its own policy", async () => {
+    const response = await preflight(
+      "/api/admin/users/115164401/role",
+      "PATCH",
+    );
+
+    // Falling through unanswered is the point: whatever this app replies with
+    // is what the browser enforces for the admin API too.
+    expect(response.headers.get("access-control-allow-methods")).toBeNull();
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("still answers preflights for its own endpoints", async () => {
+    const response = await preflight(
+      "/.well-known/openid-configuration",
+      "GET",
+    );
+
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("access-control-allow-methods")).toContain(
+      "GET",
+    );
+  });
+});

--- a/services/secure-api/src/oidc.tsx
+++ b/services/secure-api/src/oidc.tsx
@@ -236,15 +236,29 @@ async function renderConsent(
   );
 }
 
+/**
+ * CORS for the OIDC endpoints only.
+ *
+ * This app is mounted at "/" ahead of the /api router, and Hono's cors()
+ * answers an OPTIONS preflight itself without calling next(). A "*" match
+ * therefore replies to every preflight in the whole service, including
+ * /api/**, which has its own credentialed, origin-restricted policy with a
+ * wider method list. That is how PATCH /api/admin/users/:id/role came to be
+ * refused in the browser while the route itself was fine: the preflight was
+ * answered here, advertising only GET and POST.
+ *
+ * /api owns its own policy, so this one steps aside for it.
+ */
+const oidcCors = cors({
+  origin: "*",
+  allowHeaders: ["Authorization", "Content-Type"],
+  allowMethods: ["GET", "POST"],
+  credentials: true,
+});
+
 const app = new Hono()
-  .use(
-    "*",
-    cors({
-      origin: "*",
-      allowHeaders: ["Authorization", "Content-Type"],
-      allowMethods: ["GET", "POST"],
-      credentials: true,
-    }),
+  .use("*", (c, next) =>
+    c.req.path.startsWith("/api/") ? next() : oidcCors(c, next),
   )
   .get("/.well-known/openid-configuration", (c) => {
     return c.json({


### PR DESCRIPTION
Changing a user's role from the admin console failed in the browser:

```
Access to fetch at 'https://auth.nthumods.com/api/admin/users/115164401/role'
from origin 'https://nthumods.com' has been blocked by CORS policy:
Method PATCH is not allowed by Access-Control-Allow-Methods in preflight response.
```

The route was fine — the same request succeeds from curl. The preflight was being answered by the wrong middleware.

`oidc` is mounted at `/` **ahead of** the `/api` router and matched `"*"`, and Hono's `cors()` answers an `OPTIONS` preflight itself without calling `next()`. So the OIDC policy decided CORS for every preflight in the service:

```
access-control-allow-methods: GET,POST     ← OIDC policy
access-control-allow-origin: *
```

while `/api`'s own policy — credentialed, origin-restricted, `GET POST OPTIONS DELETE PUT PATCH` — never got a look in. Adding `PATCH` to `/api` in #875 therefore changed nothing a browser could observe. Any non-GET/POST admin call was affected: role changes, bans (`PATCH`), announcement and client edits (`PATCH`), deletes (`DELETE`).

The OIDC policy now steps aside for `/api`, which owns its own. OIDC endpoints keep their wildcard policy unchanged, so third-party clients are unaffected.

Verified against production before the fix:

```
$ curl -i -X OPTIONS https://auth.nthumods.com/api/admin/users/115164401/role \
    -H 'Origin: https://nthumods.com' -H 'Access-Control-Request-Method: PATCH'
access-control-allow-methods: GET,POST
access-control-allow-origin: *
```

## Tests

`src/__tests__/cors.test.ts` asserts the preflight each subtree answers with, and I confirmed it **fails without the guard** rather than passing vacuously.

They exercise the OIDC app alone rather than the composed service on purpose: importing the `/api` router would evaluate every admin handler under this file's Prisma stub, and bun's module mocks are process-wide — the handlers' own test files would then import an already-evaluated module and fail. I hit exactly that (5 unrelated failures) on the first attempt.

97 secure-api tests pass.

## Not fixed here

`origin: "*"` alongside `credentials: true` on the OIDC endpoints is invalid per spec and browsers already ignore the credentials half. Left alone deliberately — tightening the origin there could break third-party OIDC clients such as `chumei-observe`, and it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wapcwZKVzLpmhGkVxjwKU
