### PR TITLE
docs: add CI badge to README for build status visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # 國立清華大學非公式的開源預排，選課，課表網站
 
+[![Build and Deploy](https://github.com/nthumodifications/courseweb/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/nthumodifications/courseweb/actions/workflows/build.yaml)
+
 The unofficial open-source course preselection, timetable builder, and course catalog website!
 
 We are a passionate team of students dedicated to improving the technological standards of NTHU through students. We hope that with our efforts and yours, we'll make NTHU great again!


### PR DESCRIPTION
Adds a CI status badge to `README.md`, directly under the title.

```md
[![Build and Deploy](https://github.com/nthumodifications/courseweb/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/nthumodifications/courseweb/actions/workflows/build.yaml)
```

## What the badge reports

`?branch=main`, so it reflects the most recent `build.yaml` run on `main`. On a
push to `main` the jobs that execute are `migrate-db` and `deploy-api`.

`test` and `check-migrations` are gated to pull requests
(`.github/workflows/build.yaml:23` and `:51`, `if: github.event_name ==
'pull_request'`), so they do not contribute to a `main` run. The badge is
labelled "Build and Deploy" rather than "Tests" for that reason.

No badge for `scrape.yaml`: its only trigger is `workflow_dispatch`, so the
badge would show the last time someone clicked Run rather than anything current.
Worth adding if that workflow ever gains a `schedule:` trigger, since a silently
failing scrape means stale course data.

## Suggested follow-up

Running `test` on pushes to `main` as well as on pull requests would make this
badge cover the test suite, which is what a reader expects a CI badge to mean.
It also closes a gap that exists independently of the badge: a merge that is
green on a PR can still land broken on `main` if it interacts with something
merged in between, and nothing currently reports that.

