### PR TITLE
fix(today): scale the next-up countdown to hours and days

### DIFF
--- a/apps/web/src/components/Widgets/CountdownWidget.tsx
+++ b/apps/web/src/components/Widgets/CountdownWidget.tsx
@@ -3,7 +3,7 @@ import { WidgetShell } from "./WidgetShell";
 import { semesterInfo } from "@courseweb/shared";
 import useTime from "@/hooks/useTime";
 import { Timer } from "lucide-react";
-import { format } from "date-fns";
+import { format, formatDistanceStrict } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 import { Badge, cn } from "@courseweb/ui";
 import useDictionary from "@/dictionaries/useDictionary";
@@ -12,6 +12,8 @@ import useUpcomingEvents, {
   UPCOMING_TIME_ZONE,
   UpcomingEvent,
 } from "@/hooks/useUpcomingEvents";
+import { getLocale } from "@/helpers/dateLocale";
+import { useSettings } from "@/hooks/contexts/settings";
 
 const DATE_KEY_FORMAT = "yyyy-MM-dd";
 
@@ -32,7 +34,8 @@ export const NextUpLine: FC<{
   className?: string;
 }> = ({ event, className }) => {
   const dict = useDictionary();
-
+  const { language } = useSettings();
+  const now = useTime(60_000);
   if (!event) {
     return null;
   }
@@ -43,12 +46,12 @@ export const NextUpLine: FC<{
   const status =
     event.state === "in-progress"
       ? dict.today.upcoming.in_progress
-      : event.startsInMinutes === 1
-        ? dict.today.upcoming.starts_in_one
-        : dict.today.upcoming.starts_in.replace(
-            "{minutes}",
-            String(event.startsInMinutes),
-          );
+      : dict.today.upcoming.starts_in.replace(
+          "{duration}",
+          formatDistanceStrict(event.start, now, {
+            locale: getLocale(language),
+          }),
+        );
 
   return (
     <div

--- a/apps/web/src/dictionaries/en.json
+++ b/apps/web/src/dictionaries/en.json
@@ -17,8 +17,7 @@
     "upcoming": {
       "next_up": "Next up",
       "in_progress": "In progress",
-      "starts_in": "Starts in {minutes} min",
-      "starts_in_one": "Starts in 1 min",
+      "starts_in": "Starts in {duration}",
       "all_day": "All day",
       "nothing_scheduled": "Nothing else scheduled",
       "no_events": "No upcoming dates",
@@ -561,12 +560,24 @@
         "columns": "Columns",
         "widgets": "Widgets",
         "widget_options": {
-          "schedule": { "title": "Schedule" },
-          "weather": { "title": "Weather" },
-          "pinned-apps": { "title": "Quick links" },
-          "notepad": { "title": "Notepad" },
-          "countdown": { "title": "Countdown" },
-          "bus": { "title": "Bus schedule" }
+          "schedule": {
+            "title": "Schedule"
+          },
+          "weather": {
+            "title": "Weather"
+          },
+          "pinned-apps": {
+            "title": "Quick links"
+          },
+          "notepad": {
+            "title": "Notepad"
+          },
+          "countdown": {
+            "title": "Countdown"
+          },
+          "bus": {
+            "title": "Bus schedule"
+          }
         }
       }
     },
@@ -1767,7 +1778,10 @@
           "title": "Passwords stored on your device",
           "description": "are encrypted using AES-256-CBC encryption technology."
         },
-        { "title": "Basic password handling process", "description": "" }
+        {
+          "title": "Basic password handling process",
+          "description": ""
+        }
       ],
       "separator": ": ",
       "detail_before": "For more detailed encryption process, please refer to the",

--- a/apps/web/src/dictionaries/zh.json
+++ b/apps/web/src/dictionaries/zh.json
@@ -17,8 +17,7 @@
     "upcoming": {
       "next_up": "接下來",
       "in_progress": "進行中",
-      "starts_in": "還有 {minutes} 分鐘開始",
-      "starts_in_one": "還有 1 分鐘開始",
+      "starts_in": "還有 {duration} 開始",
       "all_day": "全天",
       "nothing_scheduled": "沒有其他安排",
       "no_events": "接下來沒有安排",
@@ -561,12 +560,24 @@
         "columns": "欄數",
         "widgets": "小工具",
         "widget_options": {
-          "schedule": { "title": "課程表" },
-          "weather": { "title": "天氣" },
-          "pinned-apps": { "title": "快速連結" },
-          "notepad": { "title": "便條紙" },
-          "countdown": { "title": "學期倒數" },
-          "bus": { "title": "公車時刻" }
+          "schedule": {
+            "title": "課程表"
+          },
+          "weather": {
+            "title": "天氣"
+          },
+          "pinned-apps": {
+            "title": "快速連結"
+          },
+          "notepad": {
+            "title": "便條紙"
+          },
+          "countdown": {
+            "title": "學期倒數"
+          },
+          "bus": {
+            "title": "公車時刻"
+          }
         }
       }
     },
@@ -1767,7 +1778,10 @@
           "title": "在您的設備上儲存的密碼",
           "description": "會使用 AES-256-CBC 加密技術來加密。"
         },
-        { "title": "基本密碼處理流程", "description": "" }
+        {
+          "title": "基本密碼處理流程",
+          "description": ""
+        }
       ],
       "separator": "：",
       "detail_before": "更詳細的加密過程請參閱",

--- a/apps/web/src/helpers/dateLocale.test.ts
+++ b/apps/web/src/helpers/dateLocale.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { formatDistanceStrict } from "date-fns";
+import { getLocale } from "./dateLocale";
+
+/**
+ * The next-up countdown composes formatDistanceStrict with getLocale, so the
+ * unit scales with the distance instead of always reading in minutes.
+ */
+const startsIn = (minutes: number, language: "en" | "zh") => {
+  const now = new Date("2026-09-12T18:23:00+08:00");
+  return formatDistanceStrict(new Date(now.getTime() + minutes * 60_000), now, {
+    locale: getLocale(language),
+  });
+};
+
+describe("countdown distance formatting", () => {
+  it("reads in minutes under an hour", () => {
+    expect(startsIn(59, "en")).toBe("59 minutes");
+    expect(startsIn(59, "zh")).toBe("59 分鐘");
+  });
+
+  it("pluralizes a single minute without a dedicated string", () => {
+    expect(startsIn(1, "en")).toBe("1 minute");
+    expect(startsIn(1, "zh")).toBe("1 分鐘");
+  });
+
+  it("scales to hours", () => {
+    expect(startsIn(90, "en")).toBe("2 hours");
+    expect(startsIn(90, "zh")).toBe("2 小時");
+  });
+
+  it("scales to days, the case that read as 2577 min", () => {
+    expect(startsIn(2577, "en")).toBe("2 days");
+    expect(startsIn(2577, "zh")).toBe("2 天");
+  });
+
+  it("stays in hours until a full day has passed", () => {
+    expect(startsIn(1439, "en")).toBe("24 hours");
+  });
+
+  it("handles the seven-day lookahead window maximum", () => {
+    expect(startsIn(7 * 24 * 60, "en")).toBe("7 days");
+    expect(startsIn(7 * 24 * 60, "zh")).toBe("7 天");
+  });
+});


### PR DESCRIPTION
The countdown only ever formatted minutes, so a class two days out read "Starts in 2577 min". The unit was baked into the dictionary string and startsInMinutes was printed verbatim, with a dedicated starts_in_one key as the only special case.

Formats with `date-fns` `formatDistanceStrict` against the locale the app already maps in `helpers/dateLocale.ts`, so the unit scales and each language pluralizes its own way: 59 分鐘, 2 小時, 2 天. That makes` starts_in_one` redundant, and the placeholder becomes `{duration}` rather than `{minutes}`.

`NextUpLine` now subscribes to its own clock at a one-minute interval. Two of its three call sites (TodaySchedule and today/page) have no ticking parent, so the duration would otherwise sit frozen until an unrelated re-render.

Distances stay in hours until a full day has passed, so something 23h59m away reads "24 hours" rather than "1 day". The window is seven days, so the largest value it can print is "7 days".

The dictionary diffs are one changed line each; the rest is dict:create rewriting one-line objects onto multiple lines.

Also while testing, there is a huge problem with local testing environment setup, I'll open another issue for that.