### PR TITLE
fix(sync): repair timetable replication

### DIFF
--- a/apps/web/src/app/[lang]/(mods-pages)/student/planner/planner-replication.tsx
+++ b/apps/web/src/app/[lang]/(mods-pages)/student/planner/planner-replication.tsx
@@ -44,6 +44,17 @@ const hasPlannerScope = (auth: ReturnType<typeof useAuth>): boolean => {
   return scopes.includes("planner");
 };
 
+const ensurePlannerResponseOk = async (
+  response: Response,
+  operation: string,
+) => {
+  if (response.ok) return;
+  const details = await response.text().catch(() => "");
+  throw new Error(
+    `${operation} failed with status ${response.status}${details ? `: ${details}` : ""}`,
+  );
+};
+
 // Provider component for setting up replication
 export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
   children,
@@ -119,33 +130,29 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       live: true,
       push: {
         async handler(changeRows) {
-          try {
-            // Filter out the _unsorted folder before pushing to server
-            const filteredChangeRows = changeRows.filter(
-              (row) => row.newDocumentState.id !== "_unsorted",
-            );
+          // Filter out the _unsorted folder before pushing to server
+          const filteredChangeRows = changeRows.filter(
+            (row) => row.newDocumentState.id !== "_unsorted",
+          );
 
-            // Skip the API call if there are no changes to push after filtering
-            if (filteredChangeRows.length === 0) {
-              return [];
-            }
-
-            const response = await client.planner.folders.push.$post(
-              {
-                json: filteredChangeRows,
-              },
-              {
-                headers: {
-                  Authorization: `Bearer ${auth.user?.access_token}`,
-                },
-              },
-            );
-            const conflicts = await response.json();
-            return conflicts as WithDeleted<FolderDocType>[];
-          } catch (error) {
-            console.error("Error pushing folders:", error);
+          // Skip the API call if there are no changes to push after filtering
+          if (filteredChangeRows.length === 0) {
             return [];
           }
+
+          const response = await client.planner.folders.push.$post(
+            {
+              json: filteredChangeRows,
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${auth.user?.access_token}`,
+              },
+            },
+          );
+          await ensurePlannerResponseOk(response, "Planner folders push");
+          const conflicts = await response.json();
+          return conflicts as WithDeleted<FolderDocType>[];
         },
       },
       pull: {
@@ -170,6 +177,7 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
             },
           );
 
+          await ensurePlannerResponseOk(response, "Planner folders pull");
           const data = await response.json();
           // Filter out _unsorted folder if it somehow exists in pulled data
           if (data.documents) {
@@ -190,10 +198,13 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       console.error("Folders replication error:", error),
     );
     replicationState.start();
-    replicationState.awaitInitialReplication().then(() => {
-      console.log("[folders] Initial replication done");
-      setFoldersInitialized(true);
-    });
+    replicationState.awaitInitialReplication().then(
+      () => {
+        console.log("[folders] Initial replication done");
+        setFoldersInitialized(true);
+      },
+      (error) => console.error("[folders] Initial replication failed:", error),
+    );
 
     return () => {
       replicationState.cancel();
@@ -215,23 +226,19 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       live: true,
       push: {
         async handler(changeRows) {
-          try {
-            const response = await client.planner.items.push.$post(
-              {
-                json: changeRows,
+          const response = await client.planner.items.push.$post(
+            {
+              json: changeRows,
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${auth.user?.access_token}`,
               },
-              {
-                headers: {
-                  Authorization: `Bearer ${auth.user?.access_token}`,
-                },
-              },
-            );
-            const conflicts = await response.json();
-            return conflicts as WithDeleted<ItemDocType>[];
-          } catch (error) {
-            console.error("Error pushing items:", error);
-            return [];
-          }
+            },
+          );
+          await ensurePlannerResponseOk(response, "Planner items push");
+          const conflicts = await response.json();
+          return conflicts as WithDeleted<ItemDocType>[];
         },
       },
       pull: {
@@ -256,6 +263,7 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
             },
           );
 
+          await ensurePlannerResponseOk(response, "Planner items pull");
           const data = await response.json();
           return {
             documents: data.documents as WithDeleted<ItemDocType>[],
@@ -269,10 +277,13 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       console.error("Items replication error:", error),
     );
     replicationState.start();
-    replicationState.awaitInitialReplication().then(() => {
-      console.log("[items] Initial replication done");
-      setItemsInitialized(true);
-    });
+    replicationState.awaitInitialReplication().then(
+      () => {
+        console.log("[items] Initial replication done");
+        setItemsInitialized(true);
+      },
+      (error) => console.error("[items] Initial replication failed:", error),
+    );
 
     return () => {
       replicationState.cancel();
@@ -294,23 +305,19 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       live: true,
       push: {
         async handler(changeRows) {
-          try {
-            const response = await client.planner.plannerdata.push.$post(
-              {
-                json: changeRows,
+          const response = await client.planner.plannerdata.push.$post(
+            {
+              json: changeRows,
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${auth.user?.access_token}`,
               },
-              {
-                headers: {
-                  Authorization: `Bearer ${auth.user?.access_token}`,
-                },
-              },
-            );
-            const conflicts = await response.json();
-            return conflicts as WithDeleted<PlannerDataDocType>[];
-          } catch (error) {
-            console.error("Error pushing plannerdata:", error);
-            return [];
-          }
+            },
+          );
+          await ensurePlannerResponseOk(response, "Planner data push");
+          const conflicts = await response.json();
+          return conflicts as WithDeleted<PlannerDataDocType>[];
         },
       },
       pull: {
@@ -335,6 +342,7 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
             },
           );
 
+          await ensurePlannerResponseOk(response, "Planner data pull");
           const data = await response.json();
 
           return {
@@ -350,10 +358,14 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       console.error("PlannerData replication error:", error),
     );
     replicationState.start();
-    replicationState.awaitInitialReplication().then(() => {
-      console.log("[plannerdata] Initial replication done");
-      setPlannerdataInitialized(true);
-    });
+    replicationState.awaitInitialReplication().then(
+      () => {
+        console.log("[plannerdata] Initial replication done");
+        setPlannerdataInitialized(true);
+      },
+      (error) =>
+        console.error("[plannerdata] Initial replication failed:", error),
+    );
 
     return () => {
       replicationState.cancel();
@@ -375,23 +387,19 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       live: true,
       push: {
         async handler(changeRows) {
-          try {
-            const response = await client.planner.semesters.push.$post(
-              {
-                json: changeRows,
+          const response = await client.planner.semesters.push.$post(
+            {
+              json: changeRows,
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${auth.user?.access_token}`,
               },
-              {
-                headers: {
-                  Authorization: `Bearer ${auth.user?.access_token}`,
-                },
-              },
-            );
-            const conflicts = await response.json();
-            return conflicts as WithDeleted<SemesterDocType>[];
-          } catch (error) {
-            console.error("Error pushing semesters:", error);
-            return [];
-          }
+            },
+          );
+          await ensurePlannerResponseOk(response, "Planner semesters push");
+          const conflicts = await response.json();
+          return conflicts as WithDeleted<SemesterDocType>[];
         },
       },
       pull: {
@@ -416,6 +424,7 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
             },
           );
 
+          await ensurePlannerResponseOk(response, "Planner semesters pull");
           const data = await response.json();
           return {
             documents: data.documents as WithDeleted<SemesterDocType>[],
@@ -429,10 +438,14 @@ export const PlannerReplicationProvider: FC<PropsWithChildren> = ({
       console.error("Semesters replication error:", error),
     );
     replicationState.start();
-    replicationState.awaitInitialReplication().then(() => {
-      console.log("[semesters] Initial replication done");
-      setSemestersInitialized(true);
-    });
+    replicationState.awaitInitialReplication().then(
+      () => {
+        console.log("[semesters] Initial replication done");
+        setSemestersInitialized(true);
+      },
+      (error) =>
+        console.error("[semesters] Initial replication failed:", error),
+    );
 
     return () => {
       replicationState.cancel();

--- a/apps/web/src/components/Timetable/LiveTimetableSync.tsx
+++ b/apps/web/src/components/Timetable/LiveTimetableSync.tsx
@@ -1,0 +1,97 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "react-oidc-context";
+import { useEffect, useRef, useState } from "react";
+import { hasCalendarScope } from "@/config/rxdb";
+import useUserTimetable from "@/hooks/contexts/useUserTimetable";
+import { useTimetableShare } from "@/hooks/useTimetableShare";
+import {
+  getLiveTimetablePayload,
+  getLiveTimetablePayloadKey,
+  getPublishedLiveTimetablePayload,
+} from "@/hooks/liveTimetableSync";
+
+/** Publishes local timetable changes for every live share owned by the user. */
+const LiveTimetableSync = () => {
+  const auth = useAuth();
+  const { courses, customItems, timetableDataReady, customItemsDataReady } =
+    useUserTimetable();
+  const { listOwnShares, updateShare } = useTimetableShare();
+  const userId = auth.user?.profile.sub;
+  const authSessionKey = auth.user?.expires_at ?? 0;
+  const accessToken = auth.user?.access_token;
+  const canSync =
+    auth.isAuthenticated &&
+    Boolean(accessToken && userId) &&
+    hasCalendarScope(auth.user?.scope);
+  const [syncRevision, setSyncRevision] = useState(0);
+  const inFlight = useRef(new Set<string>());
+  const lastPublished = useRef(new Map<string, string>());
+
+  const { data: ownShares = [] } = useQuery({
+    queryKey: ["own-shares", userId ?? "anonymous", authSessionKey],
+    queryFn: listOwnShares,
+    enabled: canSync,
+    staleTime: 4 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  });
+
+  useEffect(() => {
+    if (!canSync || !timetableDataReady || !customItemsDataReady) return;
+
+    const liveShareIds = new Set(
+      ownShares.filter((share) => share.isLive).map((share) => share.id),
+    );
+    for (const shareId of lastPublished.current.keys()) {
+      if (!liveShareIds.has(shareId)) lastPublished.current.delete(shareId);
+    }
+
+    for (const share of ownShares) {
+      if (!share.isLive || inFlight.current.has(share.id)) continue;
+
+      const payload = getLiveTimetablePayload(
+        share.semesters,
+        courses,
+        customItems,
+      );
+      const payloadKey = getLiveTimetablePayloadKey(payload);
+      const publishedKey = getLiveTimetablePayloadKey(
+        getPublishedLiveTimetablePayload(share),
+      );
+
+      if (
+        payloadKey === publishedKey ||
+        lastPublished.current.get(share.id) === payloadKey
+      ) {
+        continue;
+      }
+
+      inFlight.current.add(share.id);
+      void updateShare(share.id, payload)
+        .then(() => {
+          lastPublished.current.set(share.id, payloadKey);
+          // A local edit may have happened while the request was in flight.
+          setSyncRevision((revision) => revision + 1);
+        })
+        .catch((error: unknown) => {
+          console.error(`[live timetable ${share.id}] update failed`, error);
+        })
+        .finally(() => {
+          inFlight.current.delete(share.id);
+        });
+    }
+  }, [
+    authSessionKey,
+    canSync,
+    courses,
+    customItems,
+    customItemsDataReady,
+    ownShares,
+    syncRevision,
+    timetableDataReady,
+    updateShare,
+  ]);
+
+  return null;
+};
+
+export default LiveTimetableSync;

--- a/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
+++ b/apps/web/src/components/Timetable/ShareTimetableDialog.tsx
@@ -392,9 +392,11 @@ const ShareTimetableDialog = ({
   >({});
 
   const { courses, customItems, semester, colorMap } = useUserTimetable();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
   const { createShare, deleteShare, listOwnShares } = useTimetableShare();
   const queryClient = useQueryClient();
+  const userId = user?.profile.sub;
+  const authSessionKey = user?.expires_at ?? 0;
 
   // Multi-semester selection
   const [selectedSemesters, setSelectedSemesters] = useState<string[]>([
@@ -418,9 +420,9 @@ const ShareTimetableDialog = ({
   );
 
   const { data: ownShares = [], isLoading: sharesLoading } = useQuery({
-    queryKey: ["own-shares"],
+    queryKey: ["own-shares", userId ?? "anonymous", authSessionKey],
     queryFn: listOwnShares,
-    enabled: open && isAuthenticated,
+    enabled: open && isAuthenticated && Boolean(userId && user?.access_token),
   });
 
   const { data: semesterCourses = [] } = useQuery({

--- a/apps/web/src/hooks/contexts/useUserTimetable.tsx
+++ b/apps/web/src/hooks/contexts/useUserTimetable.tsx
@@ -138,6 +138,7 @@ const userTimetableContext = createContext<
 >({
   getSemesterCourses: () => [],
   timetableDataReady: false,
+  customItemsDataReady: false,
   semesterCourses: [],
   timetableTheme: Object.keys(timetableColors)[0],
   currentColors: [],
@@ -240,7 +241,7 @@ const useUserTimetableProvider = (loadCourse = true) => {
     },
     [setStoredPreferences],
   );
-  const [storedCustomItems, setStoredCustomItems] =
+  const [storedCustomItems, setStoredCustomItems, customItemsDataReady] =
     useSyncedStorage<CustomTimetableStorage>(
       "timetable_custom_items",
       {},
@@ -597,6 +598,7 @@ const useUserTimetableProvider = (loadCourse = true) => {
     semesterCustomItems,
     getSemesterCustomItems,
     setCustomItems,
+    customItemsDataReady,
     hoverCourse,
     setHoverCourse,
     preferences,

--- a/apps/web/src/hooks/liveTimetableSync.test.ts
+++ b/apps/web/src/hooks/liveTimetableSync.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getLiveTimetablePayload,
+  getLiveTimetablePayloadKey,
+  getPublishedLiveTimetablePayload,
+} from "./liveTimetableSync";
+
+describe("live timetable payloads", () => {
+  it("publishes only selected semesters and keeps empty semesters for deletions", () => {
+    const payload = getLiveTimetablePayload(
+      ["11510", "11420"],
+      {
+        "11510": ["11510CS 101000"],
+        "11310": ["11310CS 101000"],
+      },
+      {
+        "11510": [
+          {
+            id: "lab",
+            title: "Lab",
+            color: "#123456",
+            slots: [{ day: 1, start: "09:00", end: "10:00" }],
+          },
+        ],
+      },
+    );
+
+    expect(payload).toEqual({
+      courses: { "11510": ["11510CS 101000"], "11420": [] },
+      customItems: {
+        "11510": [
+          {
+            id: "lab",
+            title: "Lab",
+            color: "#123456",
+            slots: [{ day: 1, start: "09:00", end: "10:00" }],
+          },
+        ],
+        "11420": [],
+      },
+    });
+  });
+
+  it("matches an already-published live share without scheduling an update", () => {
+    const share = {
+      semesters: ["11510"],
+      courses: { "11510": ["11510CS 101000"] },
+      customItems: { "11510": [] },
+    } as const;
+    const payload = getLiveTimetablePayload(
+      share.semesters,
+      share.courses,
+      share.customItems,
+    );
+
+    expect(getLiveTimetablePayloadKey(payload)).toBe(
+      getLiveTimetablePayloadKey(getPublishedLiveTimetablePayload(share)),
+    );
+  });
+});

--- a/apps/web/src/hooks/liveTimetableSync.ts
+++ b/apps/web/src/hooks/liveTimetableSync.ts
@@ -1,0 +1,36 @@
+import type { SharedTimetable } from "./useTimetableShare";
+import type { CustomTimetableItemInput } from "@/types/timetable";
+
+export type LiveTimetablePayload = {
+  courses: Record<string, string[]>;
+  customItems: Record<string, CustomTimetableItemInput[]>;
+};
+
+/**
+ * Build the portion of the local timetable selected by a live share.
+ * Empty arrays are intentional because they propagate deletions.
+ */
+export const getLiveTimetablePayload = (
+  semesters: readonly string[],
+  courses: Readonly<Record<string, readonly string[]>>,
+  customItems: Readonly<Record<string, readonly CustomTimetableItemInput[]>>,
+): LiveTimetablePayload => ({
+  courses: Object.fromEntries(
+    semesters.map((semester) => [semester, [...(courses[semester] ?? [])]]),
+  ),
+  customItems: Object.fromEntries(
+    semesters.map((semester) => [semester, [...(customItems[semester] ?? [])]]),
+  ),
+});
+
+export const getLiveTimetablePayloadKey = (payload: LiveTimetablePayload) =>
+  JSON.stringify(payload);
+
+export const getPublishedLiveTimetablePayload = (
+  share: Pick<SharedTimetable, "semesters" | "courses" | "customItems">,
+) =>
+  getLiveTimetablePayload(
+    share.semesters,
+    share.courses,
+    share.customItems ?? {},
+  );

--- a/apps/web/src/hooks/useSavedTimetables.ts
+++ b/apps/web/src/hooks/useSavedTimetables.ts
@@ -6,11 +6,13 @@ export function useSavedTimetables() {
   const auth = useAuth();
   const { listSaved, unsaveShare, updateSaved } = useTimetableShare();
   const queryClient = useQueryClient();
+  const userId = auth.user?.profile.sub;
+  const authSessionKey = auth.user?.expires_at ?? 0;
 
   const { data: savedTimetables = [], isLoading } = useQuery({
-    queryKey: ["saved-timetables"],
+    queryKey: ["saved-timetables", userId ?? "anonymous", authSessionKey],
     queryFn: listSaved,
-    enabled: auth.isAuthenticated,
+    enabled: auth.isAuthenticated && Boolean(userId && auth.user?.access_token),
     refetchInterval: 5 * 60 * 1000, // poll every 5 min
     staleTime: 4 * 60 * 1000,
   });

--- a/apps/web/src/layouts/AppProviders.tsx
+++ b/apps/web/src/layouts/AppProviders.tsx
@@ -11,6 +11,7 @@ import TitleUpdater from "@/layouts/TitleUpdater";
 import RootErrorFallback from "@/app/error";
 import { ThemeProvider } from "@/hooks/contexts/theme";
 import { useSettings } from "@/hooks/contexts/settings";
+import LiveTimetableSync from "@/components/Timetable/LiveTimetableSync";
 
 const ThemeWrapper = ({ children }: { children: React.ReactNode }) => {
   const { darkMode } = useSettings();
@@ -26,6 +27,7 @@ const AppProviders = () => {
             <SettingsProvider>
               <ThemeWrapper>
                 <UserTimetableProvider>
+                  <LiveTimetableSync />
                   <TitleUpdater />
                   <Outlet />
                   <Toaster />


### PR DESCRIPTION
## Summary

- publish owner-side changes to live timetable shares globally, including selected-semester removals and custom items
- scope saved-share queries to the authenticated account/session
- propagate planner replication HTTP failures instead of acknowledging failed writes

## Validation

- `bun test apps/web/src/hooks/liveTimetableSync.test.ts apps/web/src/hooks/syncedStorage.test.ts apps/web/src/components/Calendar/timetableReconcile.test.ts` — 20 passed
- `bun test services/api/src --timeout 30000` — 105 passed
- `bun test services/secure-api/src --timeout 30000` — 98 passed
- `bun run --filter @courseweb/web build` — passed
- production route matrix — CORS preflight 204; protected endpoints return 401 without auth; public share GET returns 200

## Notes

The live-share defect was reproduced at code-path level: after creating a share, local timetable edits had no PUT to `/timetable-share/:id`. Authenticated end-to-end save testing was not available because the local browser session was signed out.

Repository-wide TypeScript and ESLint checks remain blocked by pre-existing missing workspace dependencies/type-generation issues; the changed code passed the focused tests and production web build.