### PR TITLE
fix(secure-api): unblock Docker image builds

### DIFF
--- a/services/secure-api/Dockerfile
+++ b/services/secure-api/Dockerfile
@@ -34,15 +34,13 @@ COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
 
 # Build shared packages first
-RUN cd packages/shared && bun run build || true
-RUN cd packages/database && bun run build || true
-RUN cd packages/eslint-config && bun run build || true
+RUN cd packages/shared && bun run build
 
 # Generate Prisma client for secure-api
 RUN cd services/secure-api && bun run prisma:generate
 
 # Build secure-api
-RUN cd services/secure-api && bun run build || true
+RUN cd services/secure-api && bun run build
 
 # Production image
 FROM base AS release

--- a/services/secure-api/package.json
+++ b/services/secure-api/package.json
@@ -10,7 +10,7 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name init",
     "tailwind:watch": "tailwindcss -i ./src/pages/input.css -o ./src/pages/public/output.css --watch",
-    "build": "bun run tailwind:build && tsc --outDir dist",
+    "build": "tsc --outDir dist",
     "clean": "rm -rf dist",
     "lint": "echo 'Secure API lint check'",
     "test": "bun test",


### PR DESCRIPTION
## Summary

- Stop running the Tailwind v4 generator in the secure-api production build; the generated consent stylesheet is already committed at `src/pages/public/output.css`.
- Remove Docker build error masking and the two package build commands for packages that do not define a build script.
- Ensure a failed shared or secure-api build prevents an image with a missing `dist` directory from being published.

Closes #888

## Validation

- `bun run build` in `services/secure-api`: passed
- `bun test` in `services/secure-api`: 98 passed
- `bun run build` in `packages/shared`: passed
- `git diff --check`: passed
- Docker CLI is unavailable in the validation environment, so the image build itself could not be run locally.
