### PR TITLE
fix(search): stop local search hanging on "Preparing local course search…"

### DIFF
--- a/apps/web/src/components/Search/SearchDegradationBanner.tsx
+++ b/apps/web/src/components/Search/SearchDegradationBanner.tsx
@@ -18,8 +18,10 @@ const SearchDegradationBanner = ({
   if (backend === "local-loading") {
     return (
       <Alert className="flex items-center gap-2 p-2 text-sm">
-        <Info className="h-4 w-4" />
-        <AlertDescription>Preparing local course search…</AlertDescription>
+        <Info className="h-4 w-4 shrink-0" />
+        <AlertDescription className="flex flex-1 items-center">
+          {dict.course.search.preparing_local_mode}
+        </AlertDescription>
       </Alert>
     );
   }

--- a/apps/web/src/dictionaries/en.json
+++ b/apps/web/src/dictionaries/en.json
@@ -147,6 +147,7 @@
       "search_placeholder": "Search for your course..."
     },
     "search": {
+      "preparing_local_mode": "Preparing local course search…",
       "limited_mode": "Search is running in limited mode — some filters and ranking may be unavailable.",
       "dismiss_limited_mode": "Dismiss limited search mode",
       "no_more_results": "No more results",

--- a/apps/web/src/dictionaries/zh.json
+++ b/apps/web/src/dictionaries/zh.json
@@ -147,6 +147,7 @@
       "search_placeholder": "尋找你要的課程..."
     },
     "search": {
+      "preparing_local_mode": "正在準備本地課程搜尋…",
       "limited_mode": "搜尋目前處於有限模式，部分篩選和排序功能可能無法使用。",
       "dismiss_limited_mode": "關閉有限搜尋模式提示",
       "no_more_results": "沒有更多結果",

--- a/apps/web/src/lib/local-search/engine.ts
+++ b/apps/web/src/lib/local-search/engine.ts
@@ -440,6 +440,7 @@ export class LocalSearchEngine {
   private readonly cache: SearchChunkCache;
   private readonly workerFactory: () => SearchWorker | undefined;
   private readonly chunks = new Map<string, Promise<LoadedChunk>>();
+  private readonly failedSemesters = new Set<string>();
   private readonly listeners = new Set<() => void>();
   private status: LocalSearchStatus = "idle";
   private readonly defaultSemester?: string;
@@ -556,13 +557,24 @@ export class LocalSearchEngine {
     const existing = this.chunks.get(semester);
     if (existing) return existing;
     const promise = this.loadChunk(semester).catch((error) => {
-      this.chunks.delete(semester);
+      // Keep the rejected promise cached. Deleting it made every later
+      // keystroke retry the load, so the engine never settled on "error" and
+      // the UI sat on "Preparing local course search…" indefinitely while
+      // re-requesting the chunk. One failure disables the local tier for the
+      // session and the remote tiers serve the query.
+      this.failedSemesters.add(semester);
       this.setStatus("error");
       throw error;
     });
     this.chunks.set(semester, promise);
     return promise;
   }
+
+  /** True once a semester's chunk has failed; callers must use a remote tier. */
+  hasFailed = (semester?: string) =>
+    semester === undefined
+      ? this.failedSemesters.size > 0
+      : this.failedSemesters.has(semester);
 
   private facetMaps(
     records: readonly SearchProjectionRecord[],

--- a/apps/web/src/lib/local-search/local-search.test.ts
+++ b/apps/web/src/lib/local-search/local-search.test.ts
@@ -545,6 +545,38 @@ describe("local-first resilient client", () => {
     expect(result.handled).toBe(false);
   });
 
+  test("stops retrying and stays failed after the chunk load fails", async () => {
+    // Regression: a failed load used to be evicted from the chunk cache, so
+    // every later query retried it. The engine kept flipping back to
+    // "loading" and the UI showed "Preparing local course search…" forever
+    // while re-requesting the chunk on each keystroke.
+    let fetchCalls = 0;
+    const failingLocal = createLocalSearchClient({
+      baseUrl: "https://api.example.test",
+      cache: new MemorySearchChunkCache(),
+      fetch: async () => {
+        fetchCalls += 1;
+        return new Response("broken", { status: 503 });
+      },
+      workerFactory: () => new FakeWorker(),
+      defaultSemester: "11510",
+    });
+
+    await expect(
+      failingLocal.trySearch([request({ query: "CS" })]),
+    ).rejects.toThrow();
+    const callsAfterFirst = fetchCalls;
+
+    for (const query of ["C", "CS", "CS 1", "CS 10"]) {
+      await expect(
+        failingLocal.trySearch([request({ query })]),
+      ).rejects.toThrow();
+    }
+
+    expect(fetchCalls).toBe(callsAfterFirst);
+    expect(failingLocal.getStatus()).toBe("error");
+  });
+
   test("falls back after manifest errors and worker build errors", async () => {
     const failingLocal = createLocalSearchClient({
       baseUrl: "https://api.example.test",

--- a/services/api/src/search-chunk.test.ts
+++ b/services/api/src/search-chunk.test.ts
@@ -294,12 +294,24 @@ describe("search chunk HTTP routes", () => {
     expect((await notModified.arrayBuffer()).byteLength).toBe(0);
   });
 
-  it("uses compression when requested and returns enveloped errors", async () => {
-    const compressed = await app.request("/11510", {
-      headers: { "Accept-Encoding": "gzip" },
-    });
-    expect(compressed.status).toBe(200);
-    expect(compressed.headers.get("content-encoding")).toBe("gzip");
+  it("returns a body the client can parse, whatever encoding is offered", async () => {
+    // Regression: the endpoint used to gzip the body itself and declare
+    // Content-Encoding. The browser then handed the client gzipped bytes, so
+    // JSON.parse threw on the 0x1f8b magic and local search never loaded.
+    // Compression belongs to the edge; the body we emit must always be JSON.
+    for (const acceptEncoding of ["gzip", "br", "gzip, deflate, br", "*"]) {
+      const response = await app.request("/11510", {
+        headers: { "Accept-Encoding": acceptEncoding },
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-encoding")).toBeNull();
+
+      const bytes = new Uint8Array(await response.clone().arrayBuffer());
+      expect([bytes[0], bytes[1]]).not.toEqual([0x1f, 0x8b]);
+
+      const body = (await response.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+    }
 
     const invalid = await app.request("/not-a-semester", {
       headers: { "Accept-Encoding": "identity" },

--- a/services/api/src/search-chunk.ts
+++ b/services/api/src/search-chunk.ts
@@ -121,38 +121,6 @@ const ifNoneMatchMatches = (header: string | undefined, etag: string) =>
       (value) => value === "*" || value === etag || value === `W/${etag}`,
     ) ?? false;
 
-type CompressionEncoding = "br" | "gzip";
-
-const getEncodingQuality = (header: string, encoding: CompressionEncoding) => {
-  const parts = header.split(",").map((part) => part.trim());
-  const wildcard = parts.find((part) => part.startsWith("*"));
-  const matching = parts.find((part) => {
-    const name = part.split(";", 1)[0]!.trim().toLowerCase();
-    return name === encoding;
-  });
-  const value = matching ?? wildcard;
-  if (!value) return 0;
-  const quality = value.match(/(?:^|;)\s*q\s*=\s*([0-9.]+)/i)?.[1];
-  return quality === undefined ? 1 : Number(quality);
-};
-
-const getCompression = (acceptEncoding: string | undefined) => {
-  if (!acceptEncoding) return null;
-  const candidates: CompressionEncoding[] = ["br", "gzip"];
-  for (const encoding of candidates) {
-    if (getEncodingQuality(acceptEncoding, encoding) <= 0) continue;
-    try {
-      return {
-        encoding,
-        stream: new CompressionStream(encoding as "gzip"),
-      };
-    } catch {
-      // Brotli is not available in every Worker/runtime. Try gzip next.
-    }
-  }
-  return null;
-};
-
 const responseHeaders = (etag: string) =>
   new Headers({
     "Cache-Control": CHUNK_CACHE_CONTROL,
@@ -169,12 +137,10 @@ const jsonResponse = (c: Context, body: string, etag: string, status = 200) => {
     return new Response(null, { status: 304, headers });
   }
 
-  const compression = getCompression(c.req.header("Accept-Encoding"));
-  if (compression) {
-    headers.set("Content-Encoding", compression.encoding);
-    const stream = new Blob([body]).stream().pipeThrough(compression.stream);
-    return new Response(stream, { status, headers });
-  }
+  // Deliberately no manual Content-Encoding. Compressing here and declaring
+  // the encoding ourselves produced responses the browser handed to the client
+  // still gzipped, so JSON.parse saw the 0x1f8b gzip magic and threw. The edge
+  // already negotiates and applies compression for JSON responses.
   return new Response(body, { status, headers });
 };
 


### PR DESCRIPTION
P0 hotfix for three defects shipped in #892. Local course search is broken in production: the banner reads "Preparing local course search…" indefinitely and never resolves.

## 1. The chunk endpoint returned a body no browser client could parse

`/search/chunk/:semester` gzipped the response body itself and set `Content-Encoding`. Those bytes reached the client undecoded, so `JSON.parse` hit the gzip magic number and threw:

```
Local course search unavailable: SyntaxError: Unexpected token '', "\x1f\x8b..."
```

`0x1f 0x8b` is the gzip header. Every chunk load failed. Manual compression is removed — the edge already negotiates and applies compression for JSON responses.

**Why tests did not catch it:** the existing test asserted only the `content-encoding` header and never decoded the body, so it passed against a response no client could read. It now parses the body and rejects a gzip magic-number prefix across several `Accept-Encoding` values.

## 2. A failed load retried forever, so the UI never left the loading state

`getChunk` deleted the cached promise on failure, so every subsequent query retried the load. The engine never settled on `error` — it flipped back to `loading` on each keystroke, which is why the banner stayed up permanently *and* why the API was being re-requested on every character typed.

The rejected promise is now retained: one failure disables the local tier for the session and the Algolia and Supabase tiers serve the query, which is the degradation path that was always intended.

## 3. Banner alignment and a hardcoded string

The loading banner's icon and text were misaligned, and the text was hardcoded English on a bilingual site. It now mirrors the limited-mode banner's layout and reads from the dictionaries (`preparing_local_mode`, added to `en.json` and `zh.json`).

## Verification

Both regression tests were confirmed to **fail against the original code** before the fixes were applied — a P0 regression test that cannot reproduce the bug is worthless:

- gzip test: `(fail) returns a body the client can parse, whatever encoding is offered`
- retry test: `(fail) stops retrying and stays failed after the chunk load fails`

| Check | Result |
| --- | --- |
| `services/api` — `bun test` | 117 pass, 0 fail |
| `apps/web` — `bun test src` | 146 pass, 2 skip, 0 fail |
| `apps/web` — `bun run build` | passed |

Note that defect 1 is server-side, so the fix only takes effect once the API is deployed. Defect 2 makes the client degrade gracefully to Algolia in the meantime, which is what should have happened all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKHPEutc5dRore4NCaZrpE
