### PR TITLE
refactor(shared): express fullWidthToHalfWidth as a range replace

### DIFF
--- a/apps/web/src/helpers/characters.ts
+++ b/apps/web/src/helpers/characters.ts
@@ -1,19 +1,6 @@
-export const fullWidthToHalfWidth = (str: string) => {
-  //check if its a full width 0-9A-Za-z
-  const isFullWidth = (char: string) => {
-    const code = char.charCodeAt(0);
-    if (code >= 65296 && code <= 65305) return true;
-    if (code >= 65313 && code <= 65338) return true;
-    if (code >= 65345 && code <= 65370) return true;
-    return false;
-  };
-  let result = "";
-  for (const char of str) {
-    if (isFullWidth(char)) {
-      result += String.fromCharCode(char.charCodeAt(0) - 65248);
-    } else {
-      result += char;
-    }
-  }
-  return result;
-};
+const FULLWIDTH_OFFSET = 0xfee0;
+
+export const fullWidthToHalfWidth = (str: string) =>
+  str.replace(/[０-９Ａ-Ｚａ-ｚ]/g, (char) =>
+    String.fromCharCode(char.charCodeAt(0) - FULLWIDTH_OFFSET),
+  );

--- a/packages/shared/src/utils/characters.ts
+++ b/packages/shared/src/utils/characters.ts
@@ -1,19 +1,6 @@
-export const fullWidthToHalfWidth = (str: string) => {
-  //check if its a full width 0-9A-Za-z
-  const isFullWidth = (char: string) => {
-    const code = char.charCodeAt(0);
-    if (code >= 65296 && code <= 65305) return true;
-    if (code >= 65313 && code <= 65338) return true;
-    if (code >= 65345 && code <= 65370) return true;
-    return false;
-  };
-  let result = "";
-  for (const char of str) {
-    if (isFullWidth(char)) {
-      result += String.fromCharCode(char.charCodeAt(0) - 65248);
-    } else {
-      result += char;
-    }
-  }
-  return result;
-};
+const FULLWIDTH_OFFSET = 0xfee0;
+
+export const fullWidthToHalfWidth = (str: string) =>
+  str.replace(/[０-９Ａ-Ｚａ-ｚ]/g, (char) =>
+    String.fromCharCode(char.charCodeAt(0) - FULLWIDTH_OFFSET),
+  );

--- a/services/api/src/utils/characters.ts
+++ b/services/api/src/utils/characters.ts
@@ -1,19 +1,6 @@
-export const fullWidthToHalfWidth = (str: string) => {
-  //check if its a full width 0-9A-Za-z
-  const isFullWidth = (char: string) => {
-    const code = char.charCodeAt(0);
-    if (code >= 65296 && code <= 65305) return true;
-    if (code >= 65313 && code <= 65338) return true;
-    if (code >= 65345 && code <= 65370) return true;
-    return false;
-  };
-  let result = "";
-  for (const char of str) {
-    if (isFullWidth(char)) {
-      result += String.fromCharCode(char.charCodeAt(0) - 65248);
-    } else {
-      result += char;
-    }
-  }
-  return result;
-};
+const FULLWIDTH_OFFSET = 0xfee0;
+
+export const fullWidthToHalfWidth = (str: string) =>
+  str.replace(/[０-９Ａ-Ｚａ-ｚ]/g, (char) =>
+    String.fromCharCode(char.charCodeAt(0) - FULLWIDTH_OFFSET),
+  );


### PR DESCRIPTION
`fullWidthToHalfWidth` encoded its three ranges and the offset as seven decimal code points, so reading it meant decoding 65296, 65305, 65313, 65338, 65345, 65370 and 65248 to find out which characters it covers.

```ts
const FULLWIDTH_OFFSET = 0xfee0;

export const fullWidthToHalfWidth = (str: string) =>
  str.replace(/[０-９Ａ-Ｚａ-ｚ]/g, (char) =>
    String.fromCharCode(char.charCodeAt(0) - FULLWIDTH_OFFSET),
  );
```

The ranges now read as the characters they match, and the offset is named.

## Verification

Two independent checks, because equivalence to the previous implementation alone would also preserve a wrong range.

Same output as before for every BMP code point:

```
identical across all BMP code points and samples
```

And the ranges are correct against Unicode, read back from the committed file:

```
０  U+FF10   ９  U+FF19
Ａ  U+FF21   Ｚ  U+FF3A
ａ  U+FF41   ｚ  U+FF5A

U+FF10-U+FF19 -> 0123456789
U+FF21-U+FF3A -> ABCDEFGHIJKLMNOPQRSTUVWXYZ
U+FF41-U+FF5A -> abcdefghijklmnopqrstuvwxyz
```

The characters immediately outside each range stay untouched, which is what rules out an off-by-one:

```
U+FF0F ／  unchanged      U+FF1A ：  unchanged
U+FF20 ＠  unchanged      U+FF3B ［  unchanged
U+FF40 ｀  unchanged      U+FF5B ｛  unchanged
```

`：` staying full-width matters in practice: it is the most common non-ASCII, non-Han character in the course data, at 171 occurrences in semester 11510.

`services/api` type-checks with 0 errors and its 105 tests pass. `apps/web` reports 29 type errors, matching `main`.

## Three copies, all replaced

The same 19-line body existed byte-for-byte (md5 `d63b1c5e`) in three places:

- `packages/shared/src/utils/characters.ts`
- `services/api/src/utils/characters.ts`
- `apps/web/src/helpers/characters.ts`

All three are replaced, so none is left holding the older form. Only the `services/api` copy currently has an importer (`src/scheduled/syllabus.ts`); the other two are unreferenced, but no files are deleted here.

## Deliberately not included

`tools/data-sync/src/utils.ts:59` has a separate implementation using the same offset over a wider class:

```ts
str
  .replace(/[！-～]/g, (char) =>
    String.fromCharCode(char.charCodeAt(0) - 0xfee0),
  )
  .replace(/　/g, " ");
```

It converts full-width punctuation as well as alphanumerics, and maps the ideographic space U+3000 to a plain space — U+3000 is outside the Fullwidth Forms block, so the offset does not apply to it and it needs its own rule.

Both that copy and the `services/api` one normalize text that is written to the same `courses` and `syllabus` rows: `tools/data-sync/src/scrapers.ts:273` and `services/api/src/scheduled/syllabus.ts:370`. Whether a course note keeps `：` or becomes `:` therefore depends on which scraper last touched the row.
